### PR TITLE
Docs: Clarify that interoperable inbox is the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ for (conversation in allConversations) {
 }
 ```
 
+These conversations include all conversations for a user **regardless of which app created the conversation.** This functionality provides the concept of an [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox), which enables a user to access all of their conversations in any app built with XMTP.
+
+You might choose to provide an additional filtered view of conversations. To learn more, see [Handle multiple conversations with the same blockchain address](#handle-multiple-conversations-with-the-same-blockchain-address) and [Filter conversations using conversation IDs and metadata](https://xmtp.org/docs/client-sdk/javascript/tutorials/filter-conversations).
+
 ### Listen for new conversations
 
 You can also listen for new conversations being started in real-time. This will allow apps to display incoming messages from new contacts.


### PR DESCRIPTION
Based on dev feedback, added a clarification that interoperable inboxes are the default state