### PR TITLE
Add WalletConnect v1 Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,16 @@ val options = ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.PRODUC
 val client = Client().create(account = account, options = options)
 
 // Get the key bundle
-val keys = client.privateKeyBundle
+val keys = client.privateKeyBundleV1
 
 // Serialize the key bundle and store it somewhere safe
-val keysData = keys.toByteArray()
+val serializedKeys = PrivateKeyBundleV1Builder.encodeData(v1)
 ```
 
-Once you have those keys, you can create a new client with `Client.from`:
+Once you have those keys, you can create a new client with `Client().buildFrom()`:
 
 ```kotlin
-val keys = PrivateKeyBundle.parseFrom(keysData)
+val keys = PrivateKeyBundleV1Builder.fromEncodedData(serializedKeys)
 val client = Client().buildFrom(bundle = keys, options = options)
 ```
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -42,6 +42,9 @@ android {
     buildFeatures {
         viewBinding true
     }
+    configurations {
+        all*.exclude module: "bcprov-jdk15to18" // Needed for dev.pinkroom.walletconnectkit
+    }
 }
 
 dependencies {
@@ -56,10 +59,7 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.6.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'com.github.TrustWallet:wallet-connect-kotlin:1.5.6'
-    implementation 'com.github.komputing.khex:extensions:1.1.2'
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'dev.pinkroom:walletconnectkit:0.3.2'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'dev.pinkroom:walletconnectkit:0.3.2'
+    implementation 'org.web3j:crypto:5.0.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -56,6 +56,10 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.6.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'com.github.TrustWallet:wallet-connect-kotlin:1.5.6'
+    implementation 'com.github.komputing.khex:extensions:1.1.2'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.google.code.gson:gson:2.10.1'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -3,6 +3,15 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="wc" />
+        </intent>
+        <provider
+            android:authorities="list"
+            android:exported="false" />
+    </queries>
 
     <application
         android:allowBackup="true"
@@ -25,12 +34,11 @@
         </activity>
         <activity
             android:name=".connect.ConnectWalletActivity"
-            android:exported="false">
-        </activity>
+            android:exported="false"></activity>
         <activity
             android:name=".conversation.ConversationDetailActivity"
-            android:exported="false">
-        </activity>
+            android:exported="false"></activity>
+
         <service
             android:name=".account.AuthenticatorService"
             android:exported="false">

--- a/example/src/main/java/org/xmtp/android/example/account/WalletConnectAccount.kt
+++ b/example/src/main/java/org/xmtp/android/example/account/WalletConnectAccount.kt
@@ -1,0 +1,37 @@
+package org.xmtp.android.example.account
+
+import dev.pinkroom.walletconnectkit.WalletConnectKit
+import org.web3j.crypto.Keys
+import org.web3j.utils.Numeric
+import org.xmtp.android.library.SigningKey
+import org.xmtp.android.library.messages.SignatureBuilder
+import org.xmtp.proto.message.contents.SignatureOuterClass
+
+data class WalletConnectAccount(private val wcKit: WalletConnectKit) : SigningKey {
+    override val address: String
+        get() = Keys.toChecksumAddress(wcKit.address.orEmpty())
+
+    override suspend fun sign(data: ByteArray): SignatureOuterClass.Signature? {
+        return sign(String(data))
+    }
+
+    override suspend fun sign(message: String): SignatureOuterClass.Signature? {
+        runCatching { wcKit.personalSign(message) }
+            .onSuccess {
+                var result = it.result as String
+                if (result.startsWith("0x") && result.length == 132) {
+                    result = result.drop(2)
+                }
+
+                val resultData = Numeric.hexStringToByteArray(result)
+
+                // Ensure we have a valid recovery byte
+                resultData[resultData.size - 1] =
+                    (1 - resultData[resultData.size - 1] % 2).toByte()
+
+                return SignatureBuilder.buildFromSignatureData(resultData)
+            }
+            .onFailure {}
+        return null
+    }
+}

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletActivity.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletActivity.kt
@@ -5,6 +5,7 @@ import android.accounts.AccountManager
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.activity.viewModels
@@ -47,8 +48,16 @@ class ConnectWalletActivity : AppCompatActivity() {
         binding.connectButton.isEnabled = showConnectButton
         binding.connectError.isVisible = !showConnectButton
         binding.connectButton.setOnClickListener {
-            viewModel.connectWallet()
+            binding.connectButton.start(viewModel.walletConnectKit, ::onConnected, ::onDisconnected)
         }
+    }
+
+    private fun onConnected(address: String) {
+        viewModel.connectWallet()
+    }
+
+    private fun onDisconnected() {
+        Log.e("###", "DISCONNECTED")
     }
 
     private fun isConnectAvailable(): Boolean {

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletActivity.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletActivity.kt
@@ -76,7 +76,6 @@ class ConnectWalletActivity : AppCompatActivity() {
                 uiState.encodedKeyData
             )
             ConnectWalletViewModel.ConnectUiState.Unknown -> Unit
-            is ConnectWalletViewModel.ConnectUiState.Connect -> connect(uiState.uri)
         }
     }
 
@@ -100,11 +99,5 @@ class ConnectWalletActivity : AppCompatActivity() {
         binding.progress.visibility = View.VISIBLE
         binding.generateButton.visibility = View.GONE
         binding.connectButton.visibility = View.GONE
-    }
-
-    private fun connect(uri: String) {
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.data = Uri.parse("$WC_URI_SCHEME$uri")
-        startActivity(intent)
     }
 }

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletActivity.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletActivity.kt
@@ -5,7 +5,6 @@ import android.accounts.AccountManager
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.activity.viewModels
@@ -44,9 +43,9 @@ class ConnectWalletActivity : AppCompatActivity() {
             viewModel.generateWallet()
         }
 
-        val showConnectButton = isConnectAvailable()
-        binding.connectButton.isEnabled = showConnectButton
-        binding.connectError.isVisible = !showConnectButton
+        val isConnectWalletAvailable = isConnectAvailable()
+        binding.connectButton.isEnabled = isConnectWalletAvailable
+        binding.connectError.isVisible = !isConnectWalletAvailable
         binding.connectButton.setOnClickListener {
             binding.connectButton.start(viewModel.walletConnectKit, ::onConnected, ::onDisconnected)
         }
@@ -57,7 +56,7 @@ class ConnectWalletActivity : AppCompatActivity() {
     }
 
     private fun onDisconnected() {
-        Log.e("###", "DISCONNECTED")
+        // No-op currently.
     }
 
     private fun isConnectAvailable(): Boolean {
@@ -92,6 +91,7 @@ class ConnectWalletActivity : AppCompatActivity() {
         binding.progress.visibility = View.GONE
         binding.generateButton.visibility = View.VISIBLE
         binding.connectButton.visibility = View.VISIBLE
+        binding.connectError.isVisible = !isConnectAvailable()
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 
@@ -99,5 +99,6 @@ class ConnectWalletActivity : AppCompatActivity() {
         binding.progress.visibility = View.VISIBLE
         binding.generateButton.visibility = View.GONE
         binding.connectButton.visibility = View.GONE
+        binding.connectError.visibility = View.GONE
     }
 }

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletActivity.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletActivity.kt
@@ -3,11 +3,13 @@ package org.xmtp.android.example.connect
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -17,6 +19,10 @@ import org.xmtp.android.example.R
 import org.xmtp.android.example.databinding.ActivityConnectWalletBinding
 
 class ConnectWalletActivity : AppCompatActivity() {
+
+    companion object {
+        private const val WC_URI_SCHEME = "wc://wc?uri="
+    }
 
     private val viewModel: ConnectWalletViewModel by viewModels()
     private lateinit var binding: ActivityConnectWalletBinding
@@ -36,14 +42,32 @@ class ConnectWalletActivity : AppCompatActivity() {
         binding.generateButton.setOnClickListener {
             viewModel.generateWallet()
         }
+
+        val showConnectButton = isConnectAvailable()
+        binding.connectButton.isEnabled = showConnectButton
+        binding.connectError.isVisible = !showConnectButton
+        binding.connectButton.setOnClickListener {
+            viewModel.connectWallet()
+        }
+    }
+
+    private fun isConnectAvailable(): Boolean {
+        val wcIntent = Intent(Intent.ACTION_VIEW).apply {
+            data = Uri.parse(WC_URI_SCHEME)
+        }
+        return wcIntent.resolveActivity(packageManager) != null
     }
 
     private fun ensureUiState(uiState: ConnectWalletViewModel.ConnectUiState) {
         when (uiState) {
             is ConnectWalletViewModel.ConnectUiState.Error -> showError(uiState.message)
             ConnectWalletViewModel.ConnectUiState.Loading -> showLoading()
-            is ConnectWalletViewModel.ConnectUiState.Success -> signIn(uiState.address, uiState.encodedKeyData)
+            is ConnectWalletViewModel.ConnectUiState.Success -> signIn(
+                uiState.address,
+                uiState.encodedKeyData
+            )
             ConnectWalletViewModel.ConnectUiState.Unknown -> Unit
+            is ConnectWalletViewModel.ConnectUiState.Connect -> connect(uiState.uri)
         }
     }
 
@@ -59,11 +83,19 @@ class ConnectWalletActivity : AppCompatActivity() {
     private fun showError(message: String) {
         binding.progress.visibility = View.GONE
         binding.generateButton.visibility = View.VISIBLE
+        binding.connectButton.visibility = View.VISIBLE
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 
     private fun showLoading() {
         binding.progress.visibility = View.VISIBLE
         binding.generateButton.visibility = View.GONE
+        binding.connectButton.visibility = View.GONE
+    }
+
+    private fun connect(uri: String) {
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.data = Uri.parse("$WC_URI_SCHEME$uri")
+        startActivity(intent)
     }
 }

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
@@ -14,7 +14,7 @@ import org.xmtp.android.library.Client
 import org.xmtp.android.library.SigningKey
 import org.xmtp.android.library.XMTPException
 import org.xmtp.android.library.messages.PrivateKeyBuilder
-import org.xmtp.android.library.messages.buildSignature
+import org.xmtp.android.library.messages.SignatureBuilder
 import org.xmtp.proto.message.contents.SignatureOuterClass
 
 class ConnectWalletViewModel(application: Application) : AndroidViewModel(application) {
@@ -44,8 +44,8 @@ class ConnectWalletViewModel(application: Application) : AndroidViewModel(applic
         override suspend fun sign(message: String): SignatureOuterClass.Signature? {
             runCatching { wcKit.personalSign(message) }
                 .onSuccess {
-                    val result = it.result
-                    return (result as String).buildSignature()
+                    val signatureData = it.result as String
+                    return SignatureBuilder.buildFromSignatureData(signatureData)
                 }
                 .onFailure {}
             return null
@@ -86,7 +86,6 @@ class ConnectWalletViewModel(application: Application) : AndroidViewModel(applic
         object Unknown : ConnectUiState()
         object Loading : ConnectUiState()
         data class Success(val address: String, val encodedKeyData: String) : ConnectUiState()
-        data class Connect(val uri: String) : ConnectUiState()
         data class Error(val message: String) : ConnectUiState()
     }
 }

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
@@ -1,12 +1,24 @@
 package org.xmtp.android.example.connect
 
+import android.util.Log
 import androidx.annotation.UiThread
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.gson.GsonBuilder
+import com.trustwallet.walletconnect.WCClient
+import com.trustwallet.walletconnect.exceptions.InvalidSessionException
+import com.trustwallet.walletconnect.models.WCPeerMeta
+import com.trustwallet.walletconnect.models.session.WCSession
+import java.lang.Thread.sleep
+import java.net.URLEncoder
+import java.util.Random
+import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import org.komputing.khex.extensions.toNoPrefixHexString
 import org.xmtp.android.library.XMTPException
 import org.xmtp.android.library.messages.PrivateKeyBuilder
 
@@ -14,6 +26,9 @@ class ConnectWalletViewModel : ViewModel() {
 
     private val _uiState = MutableStateFlow<ConnectUiState>(ConnectUiState.Unknown)
     val uiState: StateFlow<ConnectUiState> = _uiState
+
+    private val okHttpClient = OkHttpClient.Builder().build()
+    private val gsonBuilder = GsonBuilder()
 
     @UiThread
     fun generateWallet() {
@@ -31,10 +46,57 @@ class ConnectWalletViewModel : ViewModel() {
         }
     }
 
+    @UiThread
+    fun connectWallet() {
+        viewModelScope.launch(Dispatchers.IO) {
+            _uiState.value = ConnectUiState.Loading
+            try {
+                val peerMeta = WCPeerMeta(name = "XMTP Example", url = "https://xmtp.org")
+                val key = ByteArray(32).also { Random().nextBytes(it) }.toNoPrefixHexString()
+                val bridge = URLEncoder.encode("https://safe-walletconnect.safe.global/", "UTF-8")
+                val wcURI = "wc:${UUID.randomUUID()}@1?bridge=$bridge&key=$key"
+
+                val session = WCSession.from(wcURI) ?: throw InvalidSessionException()
+                val wcClient = WCClient(gsonBuilder, okHttpClient)
+                wcClient.onDisconnect = { _, _ ->
+                    Log.e("###", "DISCONNECT")
+                    if (wcClient.session != null) {
+                        wcClient.killSession()
+                    } else {
+                        wcClient.disconnect()
+                    }
+                }
+                wcClient.onSignTransaction = { _, _->
+                    Log.e("###", "SIGN")
+                }
+                wcClient.onSessionRequest = { _, peer ->
+                    Log.e("###", "SESSION REQ PEER: $peer")
+                }
+                wcClient.onFailure = { t ->
+                    Log.e("###", "FAILURE")
+                }
+                wcClient.connect(session, peerMeta)
+                _uiState.value = ConnectUiState.Connect(wcURI)
+                for (i in 0 .. 30) {
+                    if (wcClient.isConnected) {
+                        Log.e("###", "CONNECTED!")
+                        // TODO: HOW DO WE GENERATE A PRIVATE KEY?
+                    }
+                    sleep(1000)
+                }
+                wcClient.disconnect()
+                _uiState.value = ConnectUiState.Error("Timed out connection after 30s")
+            } catch (e: Exception) {
+                _uiState.value = ConnectUiState.Error(e.message.orEmpty())
+            }
+        }
+    }
+
     sealed class ConnectUiState {
         object Unknown : ConnectUiState()
         object Loading : ConnectUiState()
-        data class Success(val address: String, val encodedKeyData: String): ConnectUiState()
-        data class Error(val message: String): ConnectUiState()
+        data class Success(val address: String, val encodedKeyData: String) : ConnectUiState()
+        data class Connect(val uri: String): ConnectUiState()
+        data class Error(val message: String) : ConnectUiState()
     }
 }

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.web3j.crypto.Keys
 import org.web3j.utils.Numeric
 import org.xmtp.android.example.ClientManager
 import org.xmtp.android.library.Client
@@ -36,7 +37,7 @@ class ConnectWalletViewModel(application: Application) : AndroidViewModel(applic
 
     data class WCAccount(private val wcKit: WalletConnectKit) : SigningKey {
         override val address: String
-            get() = wcKit.address.orEmpty()
+            get() = Keys.toChecksumAddress(wcKit.address.orEmpty())
 
         override suspend fun sign(data: ByteArray): SignatureOuterClass.Signature? {
             return sign(String(data))

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
@@ -11,10 +11,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.web3j.utils.Numeric
+import org.xmtp.android.example.ClientManager
 import org.xmtp.android.library.Client
 import org.xmtp.android.library.SigningKey
 import org.xmtp.android.library.XMTPException
 import org.xmtp.android.library.messages.PrivateKeyBuilder
+import org.xmtp.android.library.messages.PrivateKeyBundleV1Builder
 import org.xmtp.android.library.messages.SignatureBuilder
 import org.xmtp.proto.message.contents.SignatureOuterClass
 
@@ -67,9 +69,10 @@ class ConnectWalletViewModel(application: Application) : AndroidViewModel(applic
             _uiState.value = ConnectUiState.Loading
             try {
                 val wallet = PrivateKeyBuilder()
+                val client = Client().create(wallet, ClientManager.CLIENT_OPTIONS)
                 _uiState.value = ConnectUiState.Success(
                     wallet.address,
-                    wallet.encodedPrivateKeyData()
+                    PrivateKeyBundleV1Builder.encodeData(client.privateKeyBundleV1)
                 )
             } catch (e: XMTPException) {
                 _uiState.value = ConnectUiState.Error(e.message.orEmpty())
@@ -83,8 +86,11 @@ class ConnectWalletViewModel(application: Application) : AndroidViewModel(applic
             _uiState.value = ConnectUiState.Loading
             try {
                 val wallet = WCAccount(walletConnectKit)
-                val client = Client().create(wallet)
-                val bundle = client.privateKeyBundle
+                val client = Client().create(wallet, ClientManager.CLIENT_OPTIONS)
+                _uiState.value = ConnectUiState.Success(
+                    wallet.address,
+                    PrivateKeyBundleV1Builder.encodeData(client.privateKeyBundleV1)
+                )
             } catch (e: Exception) {
                 _uiState.value = ConnectUiState.Error(e.message.orEmpty())
             }

--- a/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
+++ b/example/src/main/java/org/xmtp/android/example/connect/ConnectWalletViewModel.kt
@@ -10,16 +10,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import org.web3j.crypto.Keys
-import org.web3j.utils.Numeric
 import org.xmtp.android.example.ClientManager
+import org.xmtp.android.example.account.WalletConnectAccount
 import org.xmtp.android.library.Client
-import org.xmtp.android.library.SigningKey
 import org.xmtp.android.library.XMTPException
 import org.xmtp.android.library.messages.PrivateKeyBuilder
 import org.xmtp.android.library.messages.PrivateKeyBundleV1Builder
-import org.xmtp.android.library.messages.SignatureBuilder
-import org.xmtp.proto.message.contents.SignatureOuterClass
 
 class ConnectWalletViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -34,35 +30,6 @@ class ConnectWalletViewModel(application: Application) : AndroidViewModel(applic
         appDescription = "Example app using the xmtp-android SDK"
     )
     val walletConnectKit = WalletConnectKit.Builder(walletConnectKitConfig).build()
-
-    data class WCAccount(private val wcKit: WalletConnectKit) : SigningKey {
-        override val address: String
-            get() = Keys.toChecksumAddress(wcKit.address.orEmpty())
-
-        override suspend fun sign(data: ByteArray): SignatureOuterClass.Signature? {
-            return sign(String(data))
-        }
-
-        override suspend fun sign(message: String): SignatureOuterClass.Signature? {
-            runCatching { wcKit.personalSign(message) }
-                .onSuccess {
-                    var result = it.result as String
-                    if (result.startsWith("0x") && result.length == 132) {
-                        result = result.drop(2)
-                    }
-
-                    val resultData = Numeric.hexStringToByteArray(result)
-
-                    // Ensure we have a valid recovery byte
-                    resultData[resultData.size - 1] =
-                        (1 - resultData[resultData.size - 1] % 2).toByte()
-
-                    return SignatureBuilder.buildFromSignatureData(resultData)
-                }
-                .onFailure {}
-            return null
-        }
-    }
 
     @UiThread
     fun generateWallet() {
@@ -86,7 +53,7 @@ class ConnectWalletViewModel(application: Application) : AndroidViewModel(applic
         viewModelScope.launch(Dispatchers.IO) {
             _uiState.value = ConnectUiState.Loading
             try {
-                val wallet = WCAccount(walletConnectKit)
+                val wallet = WalletConnectAccount(walletConnectKit)
                 val client = Client().create(wallet, ClientManager.CLIENT_OPTIONS)
                 _uiState.value = ConnectUiState.Success(
                     wallet.address,

--- a/example/src/main/res/layout/activity_connect_wallet.xml
+++ b/example/src/main/res/layout/activity_connect_wallet.xml
@@ -28,13 +28,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.appcompat.widget.AppCompatButton
+    <dev.pinkroom.walletconnectkit.WalletConnectButton
         android:id="@+id/connectButton"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/padding"
         android:layout_marginEnd="@dimen/padding"
-        android:text="@string/connect_wallet"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/generateButton" />

--- a/example/src/main/res/layout/activity_connect_wallet.xml
+++ b/example/src/main/res/layout/activity_connect_wallet.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -9,24 +8,50 @@
 
     <ProgressBar
         android:id="@+id/progress"
+        style="@style/Widget.AppCompat.ProgressBar"
         android:layout_width="48dp"
         android:layout_height="48dp"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        style="@style/Widget.AppCompat.ProgressBar" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/generateButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/generate_wallet"
         android:layout_margin="@dimen/padding"
-        app:layout_constraintStart_toStartOf="parent"
+        android:text="@string/generate_wallet"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/connectButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/padding"
+        android:layout_marginEnd="@dimen/padding"
+        android:text="@string/connect_wallet"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/generateButton" />
+
+    <TextView
+        android:id="@+id/connectError"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/padding"
+        android:layout_marginEnd="@dimen/padding"
+        android:gravity="center"
+        android:text="@string/no_wallet_apps"
+        android:textColor="@android:color/holo_red_dark"
+        android:textSize="12sp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/connectButton" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="error">Something went wrong</string>
 
     <string name="generate_wallet">Generate wallet</string>
+    <string name="connect_wallet">Connect wallet</string>
+    <string name="no_wallet_apps">No wallet apps installed</string>
     <string name="disconnect_wallet">Disconnect wallet</string>
     <string name="copy_address">Copy address</string>
 

--- a/library/src/main/java/org/xmtp/android/library/AuthorizedIdentity.kt
+++ b/library/src/main/java/org/xmtp/android/library/AuthorizedIdentity.kt
@@ -2,6 +2,7 @@ package org.xmtp.android.library
 
 import android.util.Base64
 import com.google.crypto.tink.subtle.Base64.encodeToString
+import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.messages.AuthDataBuilder
 import org.xmtp.android.library.messages.PrivateKey
 import org.xmtp.android.library.messages.PrivateKeyBuilder
@@ -26,7 +27,9 @@ data class AuthorizedIdentity(
 
     fun createAuthToken(): String {
         val authData = AuthDataBuilder.buildFromWalletAddress(walletAddress = address)
-        val signature = PrivateKeyBuilder(identity).sign(Util.keccak256(authData.toByteArray()))
+        val signature = runBlocking {
+            PrivateKeyBuilder(identity).sign(Util.keccak256(authData.toByteArray()))
+        }
 
         val token = Token.newBuilder().also {
             it.identityKey = authorized

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -3,12 +3,6 @@ package org.xmtp.android.library
 import android.os.Build
 import com.google.crypto.tink.subtle.Base64
 import com.google.gson.GsonBuilder
-import java.nio.charset.StandardCharsets
-import java.text.SimpleDateFormat
-import java.time.Instant
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.Keys
@@ -36,6 +30,12 @@ import org.xmtp.android.library.messages.toPublicKeyBundle
 import org.xmtp.android.library.messages.toV2
 import org.xmtp.android.library.messages.walletAddress
 import org.xmtp.proto.message.api.v1.MessageApiOuterClass
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 typealias PublishResponse = org.xmtp.proto.message.api.v1.MessageApiOuterClass.PublishResponse
 typealias QueryResponse = org.xmtp.proto.message.api.v1.MessageApiOuterClass.QueryResponse
@@ -75,12 +75,12 @@ class Client() {
         this.conversations = Conversations(client = this)
     }
 
-    fun buildFrom(bundle: PrivateKeyBundle, options: ClientOptions? = null): Client {
-        val address = bundle.v1.identityKey.publicKey.recoverWalletSignerPublicKey().walletAddress
+    fun buildFrom(bundle: PrivateKeyBundleV1, options: ClientOptions? = null): Client {
+        val address = bundle.identityKey.publicKey.recoverWalletSignerPublicKey().walletAddress
         val clientOptions = options ?: ClientOptions()
         val apiClient =
             GRPCApiClient(environment = clientOptions.api.env, secure = clientOptions.api.isSecure)
-        return Client(address = address, privateKeyBundleV1 = bundle.v1, apiClient = apiClient)
+        return Client(address = address, privateKeyBundleV1 = bundle, apiClient = apiClient)
     }
 
     fun create(account: SigningKey, options: ClientOptions? = null): Client {
@@ -92,14 +92,14 @@ class Client() {
 
     fun create(account: SigningKey, apiClient: ApiClient): Client {
         return runBlocking {
-//            try {
+            try {
                 val privateKeyBundleV1 = loadOrCreateKeys(account, apiClient)
                 val client = Client(account.address, privateKeyBundleV1, apiClient)
                 client.ensureUserContactPublished()
                 client
-//            } catch (e: java.lang.Exception) {
-//                throw XMTPException("Error creating client", e)
-//            }
+            } catch (e: java.lang.Exception) {
+                throw XMTPException("Error creating client", e)
+            }
         }
     }
 

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -3,6 +3,12 @@ package org.xmtp.android.library
 import android.os.Build
 import com.google.crypto.tink.subtle.Base64
 import com.google.gson.GsonBuilder
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.Keys
@@ -30,12 +36,6 @@ import org.xmtp.android.library.messages.toPublicKeyBundle
 import org.xmtp.android.library.messages.toV2
 import org.xmtp.android.library.messages.walletAddress
 import org.xmtp.proto.message.api.v1.MessageApiOuterClass
-import java.nio.charset.StandardCharsets
-import java.text.SimpleDateFormat
-import java.time.Instant
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
 
 typealias PublishResponse = org.xmtp.proto.message.api.v1.MessageApiOuterClass.PublishResponse
 typealias QueryResponse = org.xmtp.proto.message.api.v1.MessageApiOuterClass.QueryResponse
@@ -92,14 +92,14 @@ class Client() {
 
     fun create(account: SigningKey, apiClient: ApiClient): Client {
         return runBlocking {
-            try {
+//            try {
                 val privateKeyBundleV1 = loadOrCreateKeys(account, apiClient)
                 val client = Client(account.address, privateKeyBundleV1, apiClient)
                 client.ensureUserContactPublished()
                 client
-            } catch (e: java.lang.Exception) {
-                throw XMTPException("Error creating client", e)
-            }
+//            } catch (e: java.lang.Exception) {
+//                throw XMTPException("Error creating client", e)
+//            }
         }
     }
 
@@ -237,15 +237,15 @@ class Client() {
             conversationData.toString(StandardCharsets.UTF_8),
             ConversationV2Export::class.java
         )
-        try {
-            return importV2Conversation(export = v2Export)
+        return try {
+            importV2Conversation(export = v2Export)
         } catch (e: java.lang.Exception) {
             val v1Export = gson.fromJson(
                 conversationData.toString(StandardCharsets.UTF_8),
                 ConversationV1Export::class.java
             )
             try {
-                return importV1Conversation(export = v1Export)
+                importV1Conversation(export = v1Export)
             } catch (e: java.lang.Exception) {
                 throw XMTPException("Invalid input data", e)
             }

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library
 
+import java.util.Date
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
@@ -22,7 +23,6 @@ import org.xmtp.android.library.messages.toSignedPublicKeyBundle
 import org.xmtp.android.library.messages.walletAddress
 import org.xmtp.proto.message.contents.Contact
 import org.xmtp.proto.message.contents.Invitation
-import java.util.Date
 
 data class Conversations(
     var client: Client,
@@ -140,7 +140,7 @@ data class Conversations(
                 client.apiClient.queryTopics(
                     topics = listOf(
                         Topic.userIntro(
-                            client.address ?: ""
+                            client.address
                         )
                     )
                 ).envelopesList
@@ -175,7 +175,7 @@ data class Conversations(
             client.apiClient.queryTopics(
                 topics = listOf(
                     Topic.userInvite(
-                        client.address ?: ""
+                        client.address
                     )
                 )
             ).envelopesList
@@ -204,7 +204,7 @@ data class Conversations(
                     envelopes = listOf(
                         EnvelopeBuilder.buildFromTopic(
                             topic = Topic.userInvite(
-                                client.address ?: ""
+                                client.address
                             ),
                             timestamp = created,
                             message = sealed.toByteArray()

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -1,6 +1,5 @@
 package org.xmtp.android.library
 
-import java.util.Date
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
@@ -23,6 +22,7 @@ import org.xmtp.android.library.messages.toSignedPublicKeyBundle
 import org.xmtp.android.library.messages.walletAddress
 import org.xmtp.proto.message.contents.Contact
 import org.xmtp.proto.message.contents.Invitation
+import java.util.Date
 
 data class Conversations(
     var client: Client,

--- a/library/src/main/java/org/xmtp/android/library/SigningKey.kt
+++ b/library/src/main/java/org/xmtp/android/library/SigningKey.kt
@@ -32,7 +32,6 @@ fun SigningKey.createIdentity(identity: PrivateKeyOuterClass.PrivateKey): Author
     val signatureClass = Signature.newBuilder().build()
     val signatureText = signatureClass.createIdentityText(key = slimKey.toByteArray())
     val digest = signatureClass.ethHash(message = signatureText)
-    //TODO(elise): Updated to use signatureText so it would be human readable until we can reverse eth hash
     val signature = runBlocking { sign(signatureText) } ?: throw XMTPException("Illegal signature")
 
     val signatureData = KeyUtil.getSignatureData(signature.rawData.toByteString().toByteArray())

--- a/library/src/main/java/org/xmtp/android/library/SigningKey.kt
+++ b/library/src/main/java/org/xmtp/android/library/SigningKey.kt
@@ -1,8 +1,6 @@
 package org.xmtp.android.library
 
 import com.google.protobuf.kotlin.toByteString
-import java.math.BigInteger
-import java.util.Date
 import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.ECDSASignature
 import org.web3j.crypto.Keys
@@ -15,6 +13,8 @@ import org.xmtp.android.library.messages.rawData
 import org.xmtp.proto.message.contents.PrivateKeyOuterClass
 import org.xmtp.proto.message.contents.PublicKeyOuterClass
 import org.xmtp.proto.message.contents.SignatureOuterClass
+import java.math.BigInteger
+import java.util.Date
 
 interface SigningKey {
     val address: String

--- a/library/src/main/java/org/xmtp/android/library/messages/EncryptedPrivateKeyBundle.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/EncryptedPrivateKeyBundle.kt
@@ -1,15 +1,19 @@
 package org.xmtp.android.library.messages
 
+import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.Crypto
 import org.xmtp.android.library.SigningKey
+import org.xmtp.android.library.XMTPException
 
 typealias EncryptedPrivateKeyBundle = org.xmtp.proto.message.contents.PrivateKeyOuterClass.EncryptedPrivateKeyBundle
 
 fun EncryptedPrivateKeyBundle.decrypted(key: SigningKey): PrivateKeyBundle {
-    val signature = key.sign(
-        message = Signature.newBuilder().build()
-            .enableIdentityText(key = v1.walletPreKey.toByteArray()),
-    )
+    val signature = runBlocking {
+        key.sign(
+            message = Signature.newBuilder().build()
+                .enableIdentityText(key = v1.walletPreKey.toByteArray()),
+        )
+    } ?: throw XMTPException("Illegal signature")
     val message = Crypto.decrypt(signature.rawDataWithNormalizedRecovery, v1.ciphertext)
     return PrivateKeyBundle.parseFrom(message)
 }

--- a/library/src/main/java/org/xmtp/android/library/messages/PrivateKey.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/PrivateKey.kt
@@ -1,9 +1,6 @@
 package org.xmtp.android.library.messages
 
-import com.google.crypto.tink.subtle.Base64
 import com.google.protobuf.kotlin.toByteString
-import java.security.SecureRandom
-import java.util.Date
 import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.ECKeyPair
 import org.web3j.crypto.Hash
@@ -12,6 +9,8 @@ import org.xmtp.android.library.KeyUtil
 import org.xmtp.android.library.SigningKey
 import org.xmtp.proto.message.contents.PublicKeyOuterClass
 import org.xmtp.proto.message.contents.SignatureOuterClass
+import java.security.SecureRandom
+import java.util.Date
 
 typealias PrivateKey = org.xmtp.proto.message.contents.PrivateKeyOuterClass.PrivateKey
 
@@ -35,10 +34,6 @@ class PrivateKeyBuilder : SigningKey {
 
     constructor(key: PrivateKey) {
         privateKey = key
-    }
-
-    constructor(encodedPrivateKeyData: String) {
-        privateKey = PrivateKey.parseFrom(Base64.decode(encodedPrivateKeyData, Base64.NO_WRAP))
     }
 
     companion object {
@@ -65,10 +60,6 @@ class PrivateKeyBuilder : SigningKey {
                 publicKey = PublicKeyBuilder.buildFromSignedPublicKey(signedPrivateKey.publicKey)
             }.build()
         }
-    }
-
-    fun encodedPrivateKeyData(): String {
-        return Base64.encodeToString(privateKey.toByteArray(), Base64.NO_WRAP)
     }
 
     fun getPrivateKey(): PrivateKey {

--- a/library/src/main/java/org/xmtp/android/library/messages/PrivateKeyBundle.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/PrivateKeyBundle.kt
@@ -1,12 +1,12 @@
 package org.xmtp.android.library.messages
 
 import com.google.protobuf.kotlin.toByteString
-import java.security.SecureRandom
 import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.Crypto
 import org.xmtp.android.library.SigningKey
 import org.xmtp.android.library.XMTPException
 import org.xmtp.proto.message.contents.PrivateKeyOuterClass
+import java.security.SecureRandom
 
 typealias PrivateKeyBundle = PrivateKeyOuterClass.PrivateKeyBundle
 

--- a/library/src/main/java/org/xmtp/android/library/messages/PrivateKeyBundle.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/PrivateKeyBundle.kt
@@ -1,10 +1,12 @@
 package org.xmtp.android.library.messages
 
 import com.google.protobuf.kotlin.toByteString
+import java.security.SecureRandom
+import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.Crypto
 import org.xmtp.android.library.SigningKey
+import org.xmtp.android.library.XMTPException
 import org.xmtp.proto.message.contents.PrivateKeyOuterClass
-import java.security.SecureRandom
 
 typealias PrivateKeyBundle = PrivateKeyOuterClass.PrivateKeyBundle
 
@@ -22,7 +24,11 @@ fun PrivateKeyBundle.encrypted(key: SigningKey): EncryptedPrivateKeyBundle {
     val bundleBytes = toByteArray()
     val walletPreKey = SecureRandom().generateSeed(32)
     val signature =
-        key.sign(message = Signature.newBuilder().build().enableIdentityText(key = walletPreKey))
+        runBlocking {
+            key.sign(
+                message = Signature.newBuilder().build().enableIdentityText(key = walletPreKey)
+            )
+        } ?: throw XMTPException("Illegal signature")
     val cipherText = Crypto.encrypt(signature.rawDataWithNormalizedRecovery, bundleBytes)
     return EncryptedPrivateKeyBundle.newBuilder().apply {
         v1Builder.walletPreKey = walletPreKey.toByteString()

--- a/library/src/main/java/org/xmtp/android/library/messages/PrivateKeyBundleV1.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/PrivateKeyBundleV1.kt
@@ -1,11 +1,24 @@
 package org.xmtp.android.library.messages
 
+import com.google.crypto.tink.subtle.Base64
 import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.Hash
 import org.xmtp.android.library.SigningKey
 import org.xmtp.android.library.createIdentity
 
 typealias PrivateKeyBundleV1 = org.xmtp.proto.message.contents.PrivateKeyOuterClass.PrivateKeyBundleV1
+
+class PrivateKeyBundleV1Builder {
+    companion object {
+        fun fromEncodedData(data: String): PrivateKeyBundleV1 {
+            return PrivateKeyBundleV1.parseFrom(Base64.decode(data, Base64.NO_WRAP))
+        }
+
+        fun encodeData(privateKeyBundleV1: PrivateKeyBundleV1): String {
+            return Base64.encodeToString(privateKeyBundleV1.toByteArray(), Base64.NO_WRAP)
+        }
+    }
+}
 
 fun PrivateKeyBundleV1.generate(wallet: SigningKey): PrivateKeyBundleV1 {
     val privateKey = PrivateKeyBuilder()

--- a/library/src/main/java/org/xmtp/android/library/messages/PrivateKeyBundleV1.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/PrivateKeyBundleV1.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library.messages
 
+import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.Hash
 import org.xmtp.android.library.SigningKey
 import org.xmtp.android.library.createIdentity
@@ -12,7 +13,9 @@ fun PrivateKeyBundleV1.generate(wallet: SigningKey): PrivateKeyBundleV1 {
     var bundle = authorizedIdentity.toBundle
     var preKey = PrivateKey.newBuilder().build().generate()
     val bytesToSign = UnsignedPublicKeyBuilder.buildFromPublicKey(preKey.publicKey).toByteArray()
-    val signature = privateKey.sign(Hash.sha256(bytesToSign))
+    val signature = runBlocking {
+        privateKey.sign(Hash.sha256(bytesToSign))
+    }
 
     preKey = preKey.toBuilder().apply {
         publicKeyBuilder.signature = signature

--- a/library/src/main/java/org/xmtp/android/library/messages/Signature.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/Signature.kt
@@ -1,5 +1,9 @@
 package org.xmtp.android.library.messages
 
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECPublicKeySpec
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.ECPointUtil
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -9,14 +13,17 @@ import org.bouncycastle.util.Arrays
 import org.xmtp.android.library.Util
 import org.xmtp.android.library.toHex
 import org.xmtp.proto.message.contents.SignatureOuterClass
-import java.math.BigInteger
-import java.security.KeyFactory
-import java.security.interfaces.ECPublicKey
-import java.security.spec.ECPublicKeySpec
 
 typealias Signature = org.xmtp.proto.message.contents.SignatureOuterClass.Signature
 
 private const val MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n"
+
+fun String.buildSignature(): Signature {
+    return Signature.newBuilder().apply {
+        ecdsaCompact =
+            SignatureOuterClass.Signature.ECDSACompact.parseFrom(toByteArray())
+    }.build()
+}
 
 fun Signature.ethHash(message: String): ByteArray {
     val input = MESSAGE_PREFIX + message.length + message

--- a/library/src/main/java/org/xmtp/android/library/messages/Signature.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/Signature.kt
@@ -1,10 +1,6 @@
 package org.xmtp.android.library.messages
 
 import com.google.protobuf.kotlin.toByteString
-import java.math.BigInteger
-import java.security.KeyFactory
-import java.security.interfaces.ECPublicKey
-import java.security.spec.ECPublicKeySpec
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.ECPointUtil
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -14,6 +10,10 @@ import org.bouncycastle.util.Arrays
 import org.xmtp.android.library.Util
 import org.xmtp.android.library.toHex
 import org.xmtp.proto.message.contents.SignatureOuterClass
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECPublicKeySpec
 
 typealias Signature = org.xmtp.proto.message.contents.SignatureOuterClass.Signature
 

--- a/library/src/main/java/org/xmtp/android/library/messages/Signature.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/Signature.kt
@@ -18,11 +18,15 @@ typealias Signature = org.xmtp.proto.message.contents.SignatureOuterClass.Signat
 
 private const val MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n"
 
-fun String.buildSignature(): Signature {
-    return Signature.newBuilder().apply {
-        ecdsaCompact =
-            SignatureOuterClass.Signature.ECDSACompact.parseFrom(toByteArray())
-    }.build()
+class SignatureBuilder {
+    companion object {
+        fun buildFromSignatureData(data: String): Signature {
+            return Signature.newBuilder().apply {
+                ecdsaCompact =
+                    SignatureOuterClass.Signature.ECDSACompact.parseFrom(data.toByteArray())
+            }.build()
+        }
+    }
 }
 
 fun Signature.ethHash(message: String): ByteArray {

--- a/library/src/main/java/org/xmtp/android/library/messages/Signature.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/Signature.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library.messages
 
+import com.google.protobuf.kotlin.toByteString
 import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.interfaces.ECPublicKey
@@ -20,10 +21,10 @@ private const val MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n"
 
 class SignatureBuilder {
     companion object {
-        fun buildFromSignatureData(data: String): Signature {
-            return Signature.newBuilder().apply {
-                ecdsaCompact =
-                    SignatureOuterClass.Signature.ECDSACompact.parseFrom(data.toByteArray())
+        fun buildFromSignatureData(data: ByteArray): Signature {
+            return Signature.newBuilder().also {
+                it.ecdsaCompactBuilder.bytes = data.take(64).toByteArray().toByteString()
+                it.ecdsaCompactBuilder.recovery = data[64].toInt()
             }.build()
         }
     }

--- a/library/src/main/java/org/xmtp/android/library/messages/SignedPrivateKey.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/SignedPrivateKey.kt
@@ -1,5 +1,7 @@
 package org.xmtp.android.library.messages
 
+import kotlinx.coroutines.runBlocking
+
 typealias SignedPrivateKey = org.xmtp.proto.message.contents.PrivateKeyOuterClass.SignedPrivateKey
 
 class SignedPrivateKeyBuilder {
@@ -19,7 +21,9 @@ class SignedPrivateKeyBuilder {
 
 fun SignedPrivateKey.sign(data: ByteArray): Signature {
     val key = PrivateKeyBuilder.buildFromPrivateKeyData(secp256K1.bytes.toByteArray())
-    return PrivateKeyBuilder(key).sign(data)
+    return runBlocking {
+        PrivateKeyBuilder(key).sign(data)
+    }
 }
 
 fun SignedPrivateKey.matches(signedPublicKey: SignedPublicKey): Boolean {

--- a/library/src/test/java/org/xmtp/android/library/MessageTest.kt
+++ b/library/src/test/java/org/xmtp/android/library/MessageTest.kt
@@ -252,7 +252,7 @@ class MessageTest {
         val keyBundleData =
             Numeric.hexStringToByteArray("0a86030ac001089387b882df3012220a204a393d6ac64c10770a2585def70329f10ca480517311f0b321a5cfbbae0119951a9201089387b882df3012440a420a4092f66532cf0266d146a17060fb64148e4a6adc673c14511e45f40ac66551234a336a8feb6ef3fabdf32ea259c2a3bca32b9550c3d34e004ea59e86b42f8001ac1a430a41041c919edda3399ab7f20f5e1a9339b1c2e666e80a164fb1c6d8bc1b7dbf2be158f87c837a6364c7fb667a40c2d234d198a7c2168a928d39409ad7d35d653d319912c00108a087b882df3012220a202ade2eefefa5f8855e557d685278e8717e3f57682b66c3d73aa87896766acddc1a920108a087b882df3012440a420a404f4a90ef10e1536e4588f12c2320229008d870d2abaecd1acfefe9ca91eb6f6d56b1380b1bdebdcf9c46fb19ceb3247d5d986a4dd2bce40a4bdf694c24b08fbb1a430a4104a51efe7833c46d2f683e2eb1c07811bb96ab5e4c2000a6f06124968e8842ff8be737ad7ca92b2dabb13550cdc561df15771c8494eca7b7ca5519f6da02f76489")
         val keyBundle = PrivateKeyOuterClass.PrivateKeyBundle.parseFrom(keyBundleData)
-        val client = Client().buildFrom(bundle = keyBundle)
+        val client = Client().buildFrom(bundle = keyBundle.v1)
         val conversationJSON = (""" {"version":"v2","topic":"/xmtp/0/m-2SkdN5Qa0ZmiFI5t3RFbfwIS-OLv5jusqndeenTLvNg/proto","keyMaterial":"ATA1L0O2aTxHmskmlGKCudqfGqwA1H+bad3W/GpGOr8=","peerAddress":"0x436D906d1339fC4E951769b1699051f020373D04","createdAt":"2023-01-26T22:58:45.068Z","context":{"conversationId":"pat/messageid","metadata":{}}} """).toByteArray(UTF_8)
         val decodedConversation = client.importConversation(conversationJSON)
         val conversation = ConversationV2(

--- a/library/src/test/java/org/xmtp/android/library/PrivateKeyBundleTest.kt
+++ b/library/src/test/java/org/xmtp/android/library/PrivateKeyBundleTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import org.web3j.utils.Numeric
 import org.xmtp.android.library.messages.PrivateKeyBuilder
 import org.xmtp.android.library.messages.PrivateKeyBundle
+import org.xmtp.android.library.messages.PrivateKeyBundleV1Builder
 import org.xmtp.android.library.messages.PublicKeyBundle
 import org.xmtp.android.library.messages.SignedPublicKeyBundleBuilder
 import org.xmtp.android.library.messages.UnsignedPublicKey
@@ -33,11 +34,14 @@ class PrivateKeyBundleTest {
     @Test
     fun testSerialization() {
         val wallet = PrivateKeyBuilder()
-        val encodedKeyData = wallet.encodedPrivateKeyData()
-        val wallet2 = PrivateKeyBuilder(encodedPrivateKeyData = encodedKeyData)
+        val v1 =
+            PrivateKeyOuterClass.PrivateKeyBundleV1.newBuilder().build().generate(wallet = wallet)
+        val encodedData = PrivateKeyBundleV1Builder.encodeData(v1)
+        val v1Copy = PrivateKeyBundleV1Builder.fromEncodedData(encodedData)
+        val client = Client().buildFrom(v1Copy)
         assertEquals(
             wallet.address,
-            wallet2.address
+            client.address
         )
     }
 

--- a/library/src/test/java/org/xmtp/android/library/SignatureTest.kt
+++ b/library/src/test/java/org/xmtp/android/library/SignatureTest.kt
@@ -1,6 +1,7 @@
 package org.xmtp.android.library
 
 import com.google.protobuf.kotlin.toByteStringUtf8
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.web3j.crypto.Hash
 import org.xmtp.android.library.messages.PrivateKeyBuilder
@@ -11,7 +12,7 @@ class SignatureTest {
     fun testVerify() {
         val digest = Hash.sha256("Hello world".toByteStringUtf8().toByteArray())
         val signingKey = PrivateKeyBuilder()
-        val signature = signingKey.sign(digest)
+        val signature = runBlocking { signingKey.sign(digest) }
         assert(
             signature.verify(
                 signedBy = signingKey.getPrivateKey().publicKey,

--- a/library/src/test/java/org/xmtp/android/library/TestHelpers.kt
+++ b/library/src/test/java/org/xmtp/android/library/TestHelpers.kt
@@ -42,12 +42,12 @@ class FakeWallet : SigningKey {
     override val address: String
         get() = privateKey.walletAddress
 
-    override fun sign(data: ByteArray): Signature {
+    override suspend fun sign(data: ByteArray): Signature {
         val signature = privateKeyBuilder.sign(data)
         return signature
     }
 
-    override fun sign(message: String): Signature {
+    override suspend fun sign(message: String): Signature {
         val signature = privateKeyBuilder.sign(message)
         return signature
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 rootProject.name = "xmtp-android"


### PR DESCRIPTION
This PR adds a working WalletConnect flow using https://github.com/pink-room/walletconnectkit-android. It also serializes the keys and stores them in the AccountManager to be initialized into the client upon sign in.

In order to initialize a `Client` from a WalletConnect signature we created a new `WalletConnectAccount` class that implements `SigningKey` and handles the `personal_sign` signature.

Once signed, in you'll see a list of addresses which you have conversations with and can tap in to see any messages with that account.

<details>
<summary>Signed in screenshot</summary>

![Screenshot_20230310-154054](https://user-images.githubusercontent.com/556051/224425871-652fd8ce-26df-4572-a2dc-5129b5ba59b1.png)

</details>
