### PR TITLE
Fetch most recent message for conversation list

### DIFF
--- a/example/src/main/java/org/xmtp/android/example/conversation/ConversationViewHolder.kt
+++ b/example/src/main/java/org/xmtp/android/example/conversation/ConversationViewHolder.kt
@@ -1,8 +1,11 @@
 package org.xmtp.android.example.conversation
 
 import androidx.recyclerview.widget.RecyclerView
+import org.xmtp.android.example.ClientManager
 import org.xmtp.android.example.MainViewModel
+import org.xmtp.android.example.R
 import org.xmtp.android.example.databinding.ListItemConversationBinding
+import org.xmtp.android.example.extension.truncatedAddress
 import org.xmtp.android.library.Conversation
 
 class ConversationViewHolder(
@@ -22,6 +25,16 @@ class ConversationViewHolder(
 
     fun bind(item: MainViewModel.MainListItem.ConversationItem) {
         conversation = item.conversation
-        binding.peerAddress.text = item.conversation.peerAddress
+        binding.peerAddress.text = item.conversation.peerAddress.truncatedAddress()
+        val messageBody = item.mostRecentMessage?.body.orEmpty()
+        val isMe = item.mostRecentMessage?.senderAddress == ClientManager.client.address
+        if (messageBody.isNotBlank()) {
+            binding.messageBody.text = if (isMe) binding.root.resources.getString(
+                R.string.your_message_body,
+                messageBody
+            ) else messageBody
+        } else {
+            binding.messageBody.text = binding.root.resources.getString(R.string.empty_message)
+        }
     }
 }

--- a/example/src/main/res/layout/list_item_conversation.xml
+++ b/example/src/main/res/layout/list_item_conversation.xml
@@ -1,17 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="?attr/selectableItemBackground"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/peerAddress"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:padding="@dimen/padding"
-        app:layout_constraintTop_toTopOf="parent"
+        android:paddingTop="@dimen/padding"
+        android:paddingStart="@dimen/padding"
+        android:paddingEnd="@dimen/padding"
+        android:textColor="@android:color/black"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/messageBody"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/padding"
+        android:paddingEnd="@dimen/padding"
+        android:paddingBottom="@dimen/padding"
+        android:textSize="12sp"
+        android:maxLines="1"
+        android:ellipsize="end"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/peerAddress" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="new_message">New message</string>
     <string name="enter_address">Enter Ethereum address</string>
     <string name="create_conversation">Create conversation</string>
+    <string name="empty_message">No messages yet</string>
+    <string name="your_message_body">You: %1$s</string>
 
     <!-- Messages -->
     <string name="message_composer_hint">Type a message…</string>


### PR DESCRIPTION
This PR adds an extra synchronous call to fetch the most recent message for each item in the conversation list to show a message preview. Next up: it will be nice to add a database layer to make the app feel snappier.

![most_recent_message](https://user-images.githubusercontent.com/556051/226362725-edaec421-065d-456b-9e5f-72429b4af0a4.png)
