### PR TITLE
fix booting of local docker server for tests

### DIFF
--- a/dev/local/test/Dockerfile
+++ b/dev/local/test/Dockerfile
@@ -2,5 +2,6 @@ FROM node:19-alpine
 
 WORKDIR /code
 ADD script.js script.js
+RUN apk update && apk add git
 RUN npm install @xmtp/xmtp-js ethers
 CMD ["node", "script.js"]


### PR DESCRIPTION
We need git now in order for `npm install @xmtp/xmtp-js ethers` to work.