### PR TITLE
feat: mem cache convo list, discard decode failures

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'com.google.protobuf' version '0.9.1'
     id "org.jlleitschuh.gradle.ktlint" version "11.0.0"
-    id 'org.jetbrains.dokka'
+    id "org.jetbrains.dokka" version "1.8.10"
 }
 
 dokkaGfmPartial {

--- a/library/src/androidTest/java/org/xmtp/android/library/TestHelpers.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/TestHelpers.kt
@@ -140,12 +140,12 @@ class FakeApiClient : ApiClient {
             }.reversed()
         )
 
-        val startAt = pagination?.startTime
+        val startAt = pagination?.before
         if (startAt != null) {
             result = result.filter { it.timestampNs < startAt.time * 1_000_000 }
                 .sortedBy { it.timestampNs }.toMutableList()
         }
-        val endAt = pagination?.endTime
+        val endAt = pagination?.after
         if (endAt != null) {
             result = result.filter { it.timestampNs > endAt.time * 1_000_000 }
                 .sortedBy { it.timestampNs }.toMutableList()

--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -63,15 +63,15 @@ data class GRPCApiClient(
                     if (pagination != null) {
                         it.pagingInfo = pagination.pagingInfo
                     }
-                    if (pagination?.startTime != null) {
-                        it.endTimeNs = pagination.startTime.time * 1_000_000
+                    if (pagination?.before != null) {
+                        it.endTimeNs = pagination.before.time * 1_000_000
                         it.pagingInfo = it.pagingInfo.toBuilder().also { info ->
                             info.direction =
                                 MessageApiOuterClass.SortDirection.SORT_DIRECTION_DESCENDING
                         }.build()
                     }
-                    if (pagination?.endTime != null) {
-                        it.startTimeNs = pagination.endTime.time * 1_000_000
+                    if (pagination?.after != null) {
+                        it.startTimeNs = pagination.after.time * 1_000_000
                         it.pagingInfo = it.pagingInfo.toBuilder().also { info ->
                             info.direction =
                                 MessageApiOuterClass.SortDirection.SORT_DIRECTION_DESCENDING

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library
 
+import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import org.xmtp.android.library.messages.Envelope
 import java.util.Date
@@ -57,6 +58,15 @@ sealed class Conversation {
         return when (this) {
             is V1 -> conversationV1.decode(envelope)
             is V2 -> conversationV2.decodeEnvelope(envelope)
+        }
+    }
+
+    fun decodeOrNull(envelope: Envelope): DecodedMessage? {
+        return try {
+            decode(envelope)
+        } catch (e: Exception) {
+            Log.d("CONVERSATION", "discarding message that failed to decode", e)
+            null
         }
     }
 

--- a/library/src/main/java/org/xmtp/android/library/messages/PagingInfo.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/PagingInfo.kt
@@ -11,8 +11,8 @@ typealias PagingInfoSortDirection = SortDirection
 data class Pagination(
     val limit: Int? = null,
     val direction: PagingInfoSortDirection? = null,
-    val startTime: Date? = null,
-    val endTime: Date? = null,
+    val before: Date? = null,
+    val after: Date? = null,
 ) {
     val pagingInfo: PagingInfo
         get() {

--- a/library/src/test/java/org/xmtp/android/library/TestHelpers.kt
+++ b/library/src/test/java/org/xmtp/android/library/TestHelpers.kt
@@ -140,12 +140,12 @@ class FakeApiClient : ApiClient {
             }.reversed()
         )
 
-        val startAt = pagination?.startTime
+        val startAt = pagination?.before
         if (startAt != null) {
             result = result.filter { it.timestampNs < startAt.time * 1_000_000 }
                 .sortedBy { it.timestampNs }.toMutableList()
         }
-        val endAt = pagination?.endTime
+        val endAt = pagination?.after
         if (endAt != null) {
             result = result.filter { it.timestampNs > endAt.time * 1_000_000 }
                 .sortedBy { it.timestampNs }.toMutableList()


### PR DESCRIPTION
This adds memory caching to the `conversations.list()` method -- after the first call, later calls will only look for conversations _newer_ than the most recently listed.

This also changes the message listing and streaming calls to discard malformed messages (instead of throwing an exception and failing to list anything).