### PR TITLE
fix: use type from the reply nested content directly

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/codecs/ContentTypeId.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ContentTypeId.kt
@@ -22,3 +22,6 @@ class ContentTypeIdBuilder {
 
 val ContentTypeId.id: String
     get() = "$authorityId:$typeId"
+
+val ContentTypeId.description: String
+    get() = "$authorityId/$typeId:$versionMajor.$versionMinor"

--- a/library/src/main/java/org/xmtp/android/library/codecs/ReplyCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ReplyCodec.kt
@@ -24,19 +24,18 @@ data class ReplyCodec(override var contentType: ContentTypeId = ContentTypeReply
 
         return EncodedContent.newBuilder().also {
             it.type = ContentTypeReply
-            it.putParameters("contentType", reply.contentType.id)
+            // TODO: cut when we're certain no one is looking for "contentType" here.
+            it.putParameters("contentType", reply.contentType.description)
             it.putParameters("reference", reply.reference)
             it.content = encodeReply(replyCodec, reply.content).toByteString()
         }.build()
     }
 
     override fun decode(content: EncodedContent): Reply {
-        val contentTypeIdString =
-            content.getParametersOrThrow("contentType") ?: throw XMTPException("Codec Not Found")
         val reference =
             content.getParametersOrThrow("reference") ?: throw XMTPException("Invalid Content")
         val replyEncodedContent = EncodedContent.parseFrom(content.content)
-        val replyCodec = Client.codecRegistry.findFromId(contentTypeIdString)
+        val replyCodec = Client.codecRegistry.find(replyEncodedContent.type)
         val replyContent = replyCodec.decode(content = replyEncodedContent)
             ?: throw XMTPException("Invalid Content")
         return Reply(


### PR DESCRIPTION
This gets the nested type of a reply from the deserialized EncodedContent instead of inspecting the parameter map.

See also https://github.com/xmtp/xmtp-ios/pull/143