### PR TITLE
feat: include topic in the DecodedMessage

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/MessageTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/MessageTest.kt
@@ -242,6 +242,7 @@ class MessageTest {
         val messages = convo.messages()
         assertEquals(1, messages.size)
         assertEquals("hello from kotlin", messages[0].body)
+        assertEquals(convo.topic.description, messages[0].topic)
     }
 
     @Test
@@ -257,6 +258,7 @@ class MessageTest {
         val messages = convo.messages()
         assertEquals(1, messages.size)
         assertEquals("hello from kotlin", messages[0].body)
+        assertEquals(convo.topic, messages[0].topic)
     }
 
     @Test

--- a/library/src/main/java/org/xmtp/android/library/ConversationV1.kt
+++ b/library/src/main/java/org/xmtp/android/library/ConversationV1.kt
@@ -59,6 +59,7 @@ data class ConversationV1(
         val encodedMessage = EncodedContent.parseFrom(decrypted)
         val header = message.v1.header
         val decoded = DecodedMessage(
+            topic = envelope.contentTopic,
             encodedContent = encodedMessage,
             senderAddress = header.sender.walletAddress,
             sent = message.v1.sentAt

--- a/library/src/main/java/org/xmtp/android/library/DecodedMessage.kt
+++ b/library/src/main/java/org/xmtp/android/library/DecodedMessage.kt
@@ -6,15 +6,17 @@ import org.xmtp.proto.message.contents.Content
 import java.util.Date
 
 data class DecodedMessage(
+    var topic: String,
     var encodedContent: Content.EncodedContent,
     var senderAddress: String,
     var sent: Date
 ) {
     var id: String = ""
     companion object {
-        fun preview(body: String, senderAddress: String, sent: Date): DecodedMessage {
+        fun preview(topic: String, body: String, senderAddress: String, sent: Date): DecodedMessage {
             val encoded = TextCodec().encode(content = body)
             return DecodedMessage(
+                topic = topic,
                 encodedContent = encoded,
                 senderAddress = senderAddress,
                 sent = sent

--- a/library/src/main/java/org/xmtp/android/library/messages/MessageV2.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/MessageV2.kt
@@ -74,6 +74,7 @@ class MessageV2Builder {
                 throw XMTPException("Topic mismatch")
             }
             return DecodedMessage(
+                topic = header.topic,
                 encodedContent = encodedMessage,
                 senderAddress = signed.sender.walletAddress,
                 sent = Date(header.createdNs / 1_000_000)


### PR DESCRIPTION
This adds the conversation `topic` to the `DecodedMessage` so that it can be associated with the corresponding conversation.

This is part of fix for the leftover bits from https://github.com/xmtp/xmtp-react-native/pull/86