### PR TITLE
feat: improve PreparedMessage handling

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -597,7 +597,7 @@ class ConversationTest {
         assertEquals(conversation.version, Conversation.Version.V1)
         val preparedMessage = conversation.prepareMessage(content = "hi")
         val messageID = preparedMessage.messageId
-        preparedMessage.send()
+        conversation.send(prepared = preparedMessage)
         val messages = conversation.messages()
         val message = messages[0]
         assertEquals("hi", message.body)
@@ -609,7 +609,23 @@ class ConversationTest {
         val conversation = aliceClient.conversations.newConversation(bob.walletAddress)
         val preparedMessage = conversation.prepareMessage(content = "hi")
         val messageID = preparedMessage.messageId
-        preparedMessage.send()
+        conversation.send(prepared = preparedMessage)
+        val messages = conversation.messages()
+        val message = messages[0]
+        assertEquals("hi", message.body)
+        assertEquals(message.id, messageID)
+    }
+
+    @Test
+    fun testCanSendPreparedMessageWithoutConversation() {
+        val conversation = aliceClient.conversations.newConversation(bob.walletAddress)
+        val preparedMessage = conversation.prepareMessage(content = "hi")
+        val messageID = preparedMessage.messageId
+
+        // This does not need the `conversation` to `.publish` the message.
+        // This simulates a background task publishing all pending messages upon connection.
+        aliceClient.publish(envelopes = preparedMessage.envelopes)
+
         val messages = conversation.messages()
         val message = messages[0]
         assertEquals("hi", message.body)

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -105,6 +105,13 @@ sealed class Conversation {
         }
     }
 
+    fun send(prepared: PreparedMessage) {
+        when (this) {
+            is V1 -> conversationV1.send(prepared = prepared)
+            is V2 -> conversationV2.send(prepared = prepared)
+        }
+    }
+
     fun <T> send(content: T, options: SendOptions? = null) {
         when (this) {
             is V1 -> conversationV1.send(content = content, options = options)

--- a/library/src/main/java/org/xmtp/android/library/ConversationV2.kt
+++ b/library/src/main/java/org/xmtp/android/library/ConversationV2.kt
@@ -100,20 +100,22 @@ data class ConversationV2(
 
     fun <T> send(content: T, options: SendOptions? = null): String {
         val preparedMessage = prepareMessage(content = content, options = options)
-        preparedMessage.send()
-        return preparedMessage.messageId
+        return send(preparedMessage)
     }
 
     fun send(text: String, options: SendOptions? = null, sentAt: Date? = null): String {
         val preparedMessage = prepareMessage(content = text, options = options)
-        preparedMessage.send()
-        return preparedMessage.messageId
+        return send(preparedMessage)
     }
 
     fun send(encodedContent: EncodedContent, options: SendOptions?): String {
         val preparedMessage = prepareMessage(encodedContent = encodedContent, options = options)
-        preparedMessage.send()
-        return preparedMessage.messageId
+        return send(preparedMessage)
+    }
+
+    fun send(prepared: PreparedMessage): String {
+        client.publish(envelopes = prepared.envelopes)
+        return prepared.messageId
     }
 
     fun <Codec : ContentCodec<T>, T> encode(codec: Codec, content: T): ByteArray {
@@ -170,9 +172,7 @@ data class ConversationV2(
             timestamp = Date(),
             message = MessageBuilder.buildFromMessageV2(v2 = message).toByteArray()
         )
-        return PreparedMessage(messageEnvelope = envelope, conversation = Conversation.V2(this)) {
-            client.publish(envelopes = listOf(envelope))
-        }
+        return PreparedMessage(listOf(envelope))
     }
 
     private fun generateId(envelope: Envelope): String =

--- a/library/src/main/java/org/xmtp/android/library/PreparedMessage.kt
+++ b/library/src/main/java/org/xmtp/android/library/PreparedMessage.kt
@@ -2,20 +2,37 @@ package org.xmtp.android.library
 
 import org.web3j.crypto.Hash
 import org.xmtp.android.library.messages.Envelope
+import org.xmtp.proto.message.api.v1.MessageApiOuterClass.PublishRequest
 
+// This houses a fully prepared message that can be published
+// as soon as the API client has connectivity.
+//
+// To support persistence layers that queue pending messages (e.g. while offline)
+// this struct supports serializing to/from bytes that can be written to disk or elsewhere.
+// See toSerializedData() and fromSerializedData()
 data class PreparedMessage(
-    var messageEnvelope: Envelope,
-    var conversation: Conversation,
-    var onSend: () -> Unit,
+    // The first envelope should send the message to the conversation itself.
+    // Any more are for required intros/invites etc.
+    // A client can just publish these when it has connectivity.
+    val envelopes: List<Envelope>
 ) {
+    companion object {
+        fun fromSerializedData(data: ByteArray): PreparedMessage {
+            val req = PublishRequest.parseFrom(data)
+            return PreparedMessage(req.envelopesList)
+        }
+    }
 
-    fun decodedMessage(): DecodedMessage =
-        conversation.decode(messageEnvelope)
-
-    fun send() {
-        onSend()
+    fun toSerializedData(): ByteArray {
+        val req = PublishRequest.newBuilder()
+            .addAllEnvelopes(envelopes)
+            .build()
+        return req.toByteArray()
     }
 
     val messageId: String
-        get() = Hash.sha256(messageEnvelope.message.toByteArray()).toHex()
+        get() = Hash.sha256(envelopes.first().message.toByteArray()).toHex()
+
+    val conversationTopic: String
+        get() = envelopes.first().contentTopic
 }

--- a/library/src/test/java/org/xmtp/android/library/PreparedMessageTest.kt
+++ b/library/src/test/java/org/xmtp/android/library/PreparedMessageTest.kt
@@ -1,0 +1,30 @@
+package org.xmtp.android.library
+
+import com.google.protobuf.kotlin.toByteStringUtf8
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.xmtp.android.library.messages.Envelope
+
+class PreparedMessageTest {
+
+    @Test
+    fun testSerializing() {
+        val original = PreparedMessage(
+            listOf(
+                Envelope.newBuilder().apply {
+                    contentTopic = "topic1"
+                    timestampNs = 1234
+                    message = "abc123".toByteStringUtf8()
+                }.build(),
+                Envelope.newBuilder().apply {
+                    contentTopic = "topic2"
+                    timestampNs = 5678
+                    message = "def456".toByteStringUtf8()
+                }.build(),
+            )
+        )
+        val serialized = original.toSerializedData()
+        val unserialized = PreparedMessage.fromSerializedData(serialized)
+        assertEquals(original, unserialized)
+    }
+}


### PR DESCRIPTION
This refactors `PreparedMessage` to better support apps with robust pending queue architectures:
- the `PreparedMessage` now contains the fully prepared `envelopes`
- this adds reliable serialization methods to the `PreparedMessage` for persistence

This is the Android portion of https://github.com/xmtp/xmtp-react-native/issues/82
See also https://github.com/xmtp/xmtp-ios/pull/152