### PR TITLE
feat: Move fallback content definition to content codecs

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/CodecTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/CodecTest.kt
@@ -60,6 +60,7 @@ class CodecTest {
         if (messages.size == 1) {
             val content: Double? = messages[0].content()
             assertEquals(3.14, content)
+            assertEquals("Error: This app does not support numbers.", messages[0].fallbackContent)
         }
     }
 

--- a/library/src/androidTest/java/org/xmtp/android/library/CodecTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/CodecTest.kt
@@ -36,6 +36,10 @@ data class NumberCodec(
 
     override fun decode(content: EncodedContent): Double =
         content.content.toStringUtf8().filter { it.isDigit() || it == '.' }.toDouble()
+
+    override fun fallback(content: Double): String? {
+        return "Error: This app does not support numbers."
+    }
 }
 @RunWith(AndroidJUnit4::class)
 class CodecTest {

--- a/library/src/main/java/org/xmtp/android/library/ConversationV1.kt
+++ b/library/src/main/java/org/xmtp/android/library/ConversationV1.kt
@@ -119,9 +119,13 @@ data class ConversationV1(
         }
 
         var encoded = encode(codec = codec as ContentCodec<T>, content = content)
-        encoded = encoded.toBuilder().also {
-            it.fallback = options?.contentFallback ?: ""
-        }.build()
+
+        val fallback = codec.fallback(content)
+        if (!fallback.isNullOrBlank()) {
+            encoded = encoded.toBuilder().also {
+                it.fallback = fallback
+            }.build()
+        }
         val compression = options?.compression
         if (compression != null) {
             encoded = encoded.compress(compression)

--- a/library/src/main/java/org/xmtp/android/library/ConversationV2.kt
+++ b/library/src/main/java/org/xmtp/android/library/ConversationV2.kt
@@ -147,9 +147,12 @@ data class ConversationV2(
         }
 
         var encoded = encode(codec = codec as ContentCodec<T>, content = content)
-        encoded = encoded.toBuilder().also {
-            it.fallback = options?.contentFallback ?: ""
-        }.build()
+        val fallback = codec.fallback(content)
+        if (!fallback.isNullOrBlank()) {
+            encoded = encoded.toBuilder().also {
+                it.fallback = fallback
+            }.build()
+        }
         val compression = options?.compression
         if (compression != null) {
             encoded = encoded.compress(compression)

--- a/library/src/main/java/org/xmtp/android/library/SendOptions.kt
+++ b/library/src/main/java/org/xmtp/android/library/SendOptions.kt
@@ -5,6 +5,5 @@ import org.xmtp.proto.message.contents.Content
 data class SendOptions(
     var compression: EncodedContentCompression? = null,
     var contentType: Content.ContentTypeId? = null,
-    var contentFallback: String? = null,
     var ephemeral: Boolean = false
 )

--- a/library/src/main/java/org/xmtp/android/library/codecs/AttachmentCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/AttachmentCodec.kt
@@ -34,6 +34,6 @@ data class AttachmentCodec(override var contentType: ContentTypeId = ContentType
     }
 
     override fun fallback(content: Attachment): String? {
-        return "Error: Sorry, this app cannot display attachments"
+        return "Can’t display \"${content.filename}”. This app doesn’t support attachments."
     }
 }

--- a/library/src/main/java/org/xmtp/android/library/codecs/AttachmentCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/AttachmentCodec.kt
@@ -32,4 +32,8 @@ data class AttachmentCodec(override var contentType: ContentTypeId = ContentType
             data = encodedContent,
         )
     }
+
+    override fun fallback(content: Attachment): String? {
+        return "Error: Sorry, this app cannot display attachments"
+    }
 }

--- a/library/src/main/java/org/xmtp/android/library/codecs/Composite.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/Composite.kt
@@ -48,6 +48,10 @@ class CompositeCodec : ContentCodec<DecodedComposite> {
         return fromComposite(composite = composite)
     }
 
+    override fun fallback(content: DecodedComposite): String? {
+        return null
+    }
+
     private fun toComposite(decodedComposite: DecodedComposite): Composite {
         return Composite.newBuilder().also {
             val content = decodedComposite.encodedContent

--- a/library/src/main/java/org/xmtp/android/library/codecs/ContentCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ContentCodec.kt
@@ -66,6 +66,7 @@ interface ContentCodec<T> {
     val contentType: ContentTypeId
     fun encode(content: T): EncodedContent
     fun decode(content: EncodedContent): T
+    fun fallback(content: T): String?
 }
 
 val id: String

--- a/library/src/main/java/org/xmtp/android/library/codecs/ReactionCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ReactionCodec.kt
@@ -55,6 +55,9 @@ data class ReactionCodec(override var contentType: ContentTypeId = ContentTypeRe
     }
 
     override fun fallback(content: Reaction): String? {
-        return "Error: Sorry, this app cannot display reactions"
+        return when (content.action) {
+            ReactionAction.added -> "Reacted “${content.content}” to an earlier message"
+            ReactionAction.removed -> "Removed “${content.content}” from an earlier message"
+        }
     }
 }

--- a/library/src/main/java/org/xmtp/android/library/codecs/ReactionCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ReactionCodec.kt
@@ -53,4 +53,8 @@ data class ReactionCodec(override var contentType: ContentTypeId = ContentTypeRe
             content = text,
         )
     }
+
+    override fun fallback(content: Reaction): String? {
+        return "Error: Sorry, this app cannot display reactions"
+    }
 }

--- a/library/src/main/java/org/xmtp/android/library/codecs/ReadReceiptCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ReadReceiptCodec.kt
@@ -31,4 +31,8 @@ data class ReadReceiptCodec(override var contentType: ContentTypeId = ContentTyp
 
         return ReadReceipt(timestamp = timestamp)
     }
+
+    override fun fallback(content: ReadReceipt): String? {
+        return null
+    }
 }

--- a/library/src/main/java/org/xmtp/android/library/codecs/RemoteAttachmentCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/RemoteAttachmentCodec.kt
@@ -169,6 +169,6 @@ data class RemoteAttachmentCodec(override var contentType: ContentTypeId = Conte
     }
 
     override fun fallback(content: RemoteAttachment): String? {
-        return "Error: Sorry, this app cannot display attachments"
+        return "Can’t display \"${content.filename}”. This app doesn’t support attachments."
     }
 }

--- a/library/src/main/java/org/xmtp/android/library/codecs/RemoteAttachmentCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/RemoteAttachmentCodec.kt
@@ -167,4 +167,8 @@ data class RemoteAttachmentCodec(override var contentType: ContentTypeId = Conte
             filename = filename,
         )
     }
+
+    override fun fallback(content: RemoteAttachment): String? {
+        return "Error: Sorry, this app cannot display attachments"
+    }
 }

--- a/library/src/main/java/org/xmtp/android/library/codecs/ReplyCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ReplyCodec.kt
@@ -46,7 +46,7 @@ data class ReplyCodec(override var contentType: ContentTypeId = ContentTypeReply
     }
 
     override fun fallback(content: Reply): String? {
-        return "Error: Sorry, this app cannot display quote replies"
+        return "Replied with “${content.content}” to an earlier message"
     }
 
     private fun <Codec : ContentCodec<T>, T> encodeReply(

--- a/library/src/main/java/org/xmtp/android/library/codecs/ReplyCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ReplyCodec.kt
@@ -45,6 +45,10 @@ data class ReplyCodec(override var contentType: ContentTypeId = ContentTypeReply
         )
     }
 
+    override fun fallback(content: Reply): String? {
+        return "Error: Sorry, this app cannot display quote replies"
+    }
+
     private fun <Codec : ContentCodec<T>, T> encodeReply(
         codec: Codec,
         content: Any,

--- a/library/src/main/java/org/xmtp/android/library/codecs/TextCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/TextCodec.kt
@@ -32,4 +32,8 @@ data class TextCodec(override var contentType: ContentTypeId = ContentTypeText) 
             throw XMTPException("Unknown decoding")
         }
     }
+
+    override fun fallback(content: String): String? {
+        return null
+    }
 }


### PR DESCRIPTION
Android side https://github.com/xmtp/xmtp-js/pull/426

Moves the content fallback for supported codecs into the codec itself.