### PR TITLE
Remove timestamp from read receipts

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ReadReceiptTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ReadReceiptTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.xmtp.android.library.codecs.ContentTypeId
 import org.xmtp.android.library.codecs.ContentTypeReadReceipt
 import org.xmtp.android.library.codecs.ReadReceipt
 import org.xmtp.android.library.codecs.ReadReceiptCodec

--- a/library/src/androidTest/java/org/xmtp/android/library/ReadReceiptTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ReadReceiptTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.xmtp.android.library.codecs.ContentTypeId
 import org.xmtp.android.library.codecs.ContentTypeReadReceipt
 import org.xmtp.android.library.codecs.ReadReceipt
 import org.xmtp.android.library.codecs.ReadReceiptCodec
@@ -23,7 +24,7 @@ class ReadReceiptTest {
 
         aliceConversation.send(text = "hey alice 2 bob")
 
-        val readReceipt = ReadReceipt(timestamp = "2019-09-26T07:58:30.996+0200")
+        val readReceipt = ReadReceipt
 
         aliceConversation.send(
             content = readReceipt,
@@ -32,8 +33,8 @@ class ReadReceiptTest {
         val messages = aliceConversation.messages()
         assertEquals(messages.size, 2)
         if (messages.size == 2) {
-            val content: ReadReceipt? = messages.first().content()
-            assertEquals("2019-09-26T07:58:30.996+0200", content?.timestamp)
+            val contentType: String = messages.first().encodedContent.type.typeId
+            assertEquals(contentType, "readReceipt")
         }
     }
 }

--- a/library/src/main/java/org/xmtp/android/library/codecs/ReadReceiptCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ReadReceiptCodec.kt
@@ -10,10 +10,7 @@ val ContentTypeReadReceipt = ContentTypeIdBuilder.builderFromAuthorityId(
     versionMinor = 0
 )
 
-data class ReadReceipt(
-    // The timestamp the read receipt was sent, in ISO 8601 format
-    val timestamp: String,
-)
+object ReadReceipt
 
 data class ReadReceiptCodec(override var contentType: ContentTypeId = ContentTypeReadReceipt) :
     ContentCodec<ReadReceipt> {
@@ -21,15 +18,12 @@ data class ReadReceiptCodec(override var contentType: ContentTypeId = ContentTyp
     override fun encode(content: ReadReceipt): EncodedContent {
         return EncodedContent.newBuilder().also {
             it.type = ContentTypeReadReceipt
-            it.putParameters("timestamp", content.timestamp)
             it.content = ByteString.EMPTY
         }.build()
     }
 
     override fun decode(content: EncodedContent): ReadReceipt {
-        val timestamp = content.parametersMap["timestamp"] ?: throw XMTPException("Invalid Content")
-
-        return ReadReceipt(timestamp = timestamp)
+        return ReadReceipt
     }
 
     override fun fallback(content: ReadReceipt): String? {

--- a/library/src/main/java/org/xmtp/android/library/codecs/ReadReceiptCodec.kt
+++ b/library/src/main/java/org/xmtp/android/library/codecs/ReadReceiptCodec.kt
@@ -1,7 +1,6 @@
 package org.xmtp.android.library.codecs
 
 import com.google.protobuf.ByteString
-import org.xmtp.android.library.XMTPException
 
 val ContentTypeReadReceipt = ContentTypeIdBuilder.builderFromAuthorityId(
     "xmtp.org",


### PR DESCRIPTION
Implements https://github.com/orgs/xmtp/discussions/43#discussioncomment-6972516

This removes the timestamp from the read receipt content type in favor of the timestamp already on the message.