### PR TITLE
Fix order of loading consent

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -723,6 +723,12 @@ class ConversationTest {
         assertTrue(isAllowed)
         assertTrue(bobClient.contacts.isAllowed(alice.walletAddress))
 
+        bobClient.contacts.block(listOf(alice.walletAddress))
+        bobClient.contacts.refreshConsentList()
+
+        val isBlocked = bobConversation.consentState() == ConsentState.BLOCKED
+        assertTrue(isBlocked)
+
         val aliceConversation = aliceClient.conversations.list()[0]
         val isUnknown = aliceConversation.consentState() == ConsentState.UNKNOWN
 

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -67,14 +67,22 @@ class ConsentList(val client: Client) {
             )
         }
 
-        preferences.iterator().forEach { preference ->
-            preference.allow?.walletAddressesList?.forEach { address ->
-                consentList.allow(address)
-            }
-            preference.block?.walletAddressesList?.forEach { address ->
-                consentList.block(address)
+        preferences.reversed().iterator().forEach { preference ->
+            when(preference.messageTypeCase) {
+                PrivatePreferencesAction.MessageTypeCase.ALLOW -> {
+                    preference.allow.walletAddressesList.forEach {
+                        consentList.allow(it)
+                    }
+                }
+                PrivatePreferencesAction.MessageTypeCase.BLOCK -> {
+                    preference.block.walletAddressesList.forEach {
+                        consentList.block(it)
+                    }
+                }
+                else -> Unit
             }
         }
+
         return consentList
     }
 


### PR DESCRIPTION
Turns out that consent will load the entries newest to oldest. This would make newer entries get overridden by older entries so if you allowed someone and then blocked them it would always show as allowed. 
By reversing the iteration it will take the newest entries last and succeed.