### PR TITLE
Update block to deny and add implicit consent for sending messages

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ContactsTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ContactsTest.kt
@@ -62,9 +62,9 @@ class ContactsTest {
 
         assert(!result)
 
-        contacts.block(listOf(fixtures.alice.walletAddress))
+        contacts.deny(listOf(fixtures.alice.walletAddress))
 
-        result = contacts.isBlocked(fixtures.alice.walletAddress)
+        result = contacts.isDenied(fixtures.alice.walletAddress)
         assert(result)
     }
 }

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -752,7 +752,7 @@ class ConversationTest {
     }
 
     @Test
-    fun testImplicitConsentWhenSendingAMessage() {
+    fun testCanHaveImplicitConsentOnMessageSend() {
         val bobConversation = bobClient.conversations.newConversation(alice.walletAddress, null)
         val isAllowed = bobConversation.consentState() == ConsentState.ALLOWED
 

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -771,6 +771,5 @@ class ConversationTest {
 
         // Conversations you send a message to get marked as allowed
         assertTrue(isNowAllowed)
-
     }
 }

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -406,9 +406,11 @@ class ConversationTest {
         val messages2 = aliceConversation.messages(limit = 1, after = date)
         assertEquals(1, messages2.size)
         assertEquals("hey alice 1", messages2[0].body)
-        val messagesAsc = aliceConversation.messages(direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING)
+        val messagesAsc =
+            aliceConversation.messages(direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING)
         assertEquals("hey alice 1", messagesAsc[0].body)
-        val messagesDesc = aliceConversation.messages(direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_DESCENDING)
+        val messagesDesc =
+            aliceConversation.messages(direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_DESCENDING)
         assertEquals("hey alice 3", messagesDesc[0].body)
     }
 

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -723,11 +723,11 @@ class ConversationTest {
         assertTrue(isAllowed)
         assertTrue(bobClient.contacts.isAllowed(alice.walletAddress))
 
-        bobClient.contacts.block(listOf(alice.walletAddress))
+        bobClient.contacts.deny(listOf(alice.walletAddress))
         bobClient.contacts.refreshConsentList()
 
-        val isBlocked = bobConversation.consentState() == ConsentState.BLOCKED
-        assertTrue(isBlocked)
+        val isDenied = bobConversation.consentState() == ConsentState.DENIED
+        assertTrue(isDenied)
 
         val aliceConversation = aliceClient.conversations.list()[0]
         val isUnknown = aliceConversation.consentState() == ConsentState.UNKNOWN

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -750,4 +750,27 @@ class ConversationTest {
 
         assertTrue(isBobAllowed2)
     }
+
+    @Test
+    fun testImplicitConsentWhenSendingAMessage() {
+        val bobConversation = bobClient.conversations.newConversation(alice.walletAddress, null)
+        val isAllowed = bobConversation.consentState() == ConsentState.ALLOWED
+
+        // Conversations you start should start as allowed
+        assertTrue(isAllowed)
+
+        val aliceConversation = aliceClient.conversations.list()[0]
+        val isUnknown = aliceConversation.consentState() == ConsentState.UNKNOWN
+
+        // Conversations you receive should start as unknown
+        assertTrue(isUnknown)
+
+        aliceConversation.send(content = "hey bob")
+        aliceClient.contacts.refreshConsentList()
+        val isNowAllowed = aliceConversation.consentState() == ConsentState.ALLOWED
+
+        // Conversations you send a message to get marked as allowed
+        assertTrue(isNowAllowed)
+
+    }
 }

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -11,7 +11,7 @@ import java.util.Date
 
 enum class ConsentState {
     ALLOWED,
-    BLOCKED,
+    DENIED,
     UNKNOWN
 }
 
@@ -73,7 +73,7 @@ class ConsentList(val client: Client) {
                 consentList.allow(address)
             }
             preference.block?.walletAddressesList?.forEach { address ->
-                consentList.block(address)
+                consentList.deny(address)
             }
         }
 
@@ -88,7 +88,7 @@ class ConsentList(val client: Client) {
                     PrivatePreferencesAction.Allow.newBuilder().addWalletAddresses(entry.value)
                 )
 
-                ConsentState.BLOCKED -> it.setBlock(
+                ConsentState.DENIED -> it.setBlock(
                     PrivatePreferencesAction.Block.newBuilder().addWalletAddresses(entry.value)
                 )
 
@@ -117,10 +117,10 @@ class ConsentList(val client: Client) {
         return ConsentListEntry.address(address, ConsentState.ALLOWED)
     }
 
-    fun block(address: String): ConsentListEntry {
-        entries[ConsentListEntry.address(address).key] = ConsentState.BLOCKED
+    fun deny(address: String): ConsentListEntry {
+        entries[ConsentListEntry.address(address).key] = ConsentState.DENIED
 
-        return ConsentListEntry.address(address, ConsentState.BLOCKED)
+        return ConsentListEntry.address(address, ConsentState.DENIED)
     }
 
     fun state(address: String): ConsentState {
@@ -148,8 +148,8 @@ data class Contacts(
         return consentList.state(address) == ConsentState.ALLOWED
     }
 
-    fun isBlocked(address: String): Boolean {
-        return consentList.state(address) == ConsentState.BLOCKED
+    fun isDenied(address: String): Boolean {
+        return consentList.state(address) == ConsentState.DENIED
     }
 
     fun allow(addresses: List<String>) {
@@ -158,9 +158,9 @@ data class Contacts(
         }
     }
 
-    fun block(addresses: List<String>) {
+    fun deny(addresses: List<String>) {
         for (address in addresses) {
-            ConsentList(client).publish(consentList.block(address))
+            ConsentList(client).publish(consentList.deny(address))
         }
     }
 

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -4,8 +4,10 @@ import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.messages.ContactBundle
 import org.xmtp.android.library.messages.ContactBundleBuilder
 import org.xmtp.android.library.messages.EnvelopeBuilder
+import org.xmtp.android.library.messages.Pagination
 import org.xmtp.android.library.messages.Topic
 import org.xmtp.android.library.messages.walletAddress
+import org.xmtp.proto.message.api.v1.MessageApiOuterClass
 import org.xmtp.proto.message.contents.PrivatePreferences.PrivatePreferencesAction
 import java.util.Date
 
@@ -50,7 +52,10 @@ class ConsentList(val client: Client) {
 
     @OptIn(ExperimentalUnsignedTypes::class)
     suspend fun load(): ConsentList {
-        val envelopes = client.query(Topic.preferenceList(identifier))
+        val envelopes = client.query(
+            Topic.preferenceList(identifier),
+            Pagination(direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING)
+        )
         val consentList = ConsentList(client)
         val preferences: MutableList<PrivatePreferencesAction> = mutableListOf()
 
@@ -68,7 +73,7 @@ class ConsentList(val client: Client) {
             )
         }
 
-        preferences.reversed().iterator().forEach { preference ->
+        preferences.iterator().forEach { preference ->
             preference.allow?.walletAddressesList?.forEach { address ->
                 consentList.allow(address)
             }

--- a/library/src/main/java/org/xmtp/android/library/ConversationV1.kt
+++ b/library/src/main/java/org/xmtp/android/library/ConversationV1.kt
@@ -107,6 +107,9 @@ data class ConversationV1(
 
     fun send(prepared: PreparedMessage): String {
         client.publish(envelopes = prepared.envelopes)
+        if (client.contacts.consentList.state(address = peerAddress) == ConsentState.UNKNOWN) {
+            client.contacts.allow(addresses = listOf(peerAddress))
+        }
         return prepared.messageId
     }
 

--- a/library/src/main/java/org/xmtp/android/library/ConversationV2.kt
+++ b/library/src/main/java/org/xmtp/android/library/ConversationV2.kt
@@ -119,6 +119,9 @@ data class ConversationV2(
 
     fun send(prepared: PreparedMessage): String {
         client.publish(envelopes = prepared.envelopes)
+        if (client.contacts.consentList.state(address = peerAddress) == ConsentState.UNKNOWN) {
+            client.contacts.allow(addresses = listOf(peerAddress))
+        }
         return prepared.messageId
     }
 


### PR DESCRIPTION
This addresses the items outlined here: https://github.com/orgs/xmtp/discussions/49#discussioncomment-7429217

Changes the word blocked to denied and adds implicit consent for sending a message to a conversation with unknown consent.