### PR TITLE
make canMessage method accessible on the Client class

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -2,6 +2,7 @@ package org.xmtp.android.library
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.xmtp.android.library.messages.PrivateKeyBuilder
@@ -79,6 +80,18 @@ class ClientTest {
         val notOnNetwork = PrivateKeyBuilder()
         val canMessage = fixtures.aliceClient.canMessage(fixtures.bobClient.address)
         val cannotMessage = fixtures.aliceClient.canMessage(notOnNetwork.address)
+        assert(canMessage)
+        assert(!cannotMessage)
+    }
+    @Test
+    @Ignore("CI Issues")
+    fun testPublicCanMessage() {
+        val fixtures = fixtures()
+        val notOnNetwork = PrivateKeyBuilder()
+        val clientOptions =
+            ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.LOCAL, isSecure = false, appVersion = "XMTPTest/v1.0.0"))
+        val canMessage = Client.canMessage(fixtures.bobClient.address, clientOptions)
+        val cannotMessage = Client.canMessage(notOnNetwork.address, clientOptions)
         assert(canMessage)
         assert(!cannotMessage)
     }

--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -2,7 +2,6 @@ package org.xmtp.android.library
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.xmtp.android.library.messages.PrivateKeyBuilder
@@ -37,7 +36,7 @@ class ClientTest {
         val client = Client().buildFrom(v1Copy)
         assertEquals(
             wallet.address,
-            client.address
+            client.address,
         )
     }
 
@@ -50,11 +49,11 @@ class ClientTest {
         assertEquals(client.address, clientFromV1Bundle.address)
         assertEquals(
             client.privateKeyBundleV1?.identityKey,
-            clientFromV1Bundle.privateKeyBundleV1?.identityKey
+            clientFromV1Bundle.privateKeyBundleV1?.identityKey,
         )
         assertEquals(
             client.privateKeyBundleV1?.preKeysList,
-            clientFromV1Bundle.privateKeyBundleV1?.preKeysList
+            clientFromV1Bundle.privateKeyBundleV1?.preKeysList,
         )
     }
 
@@ -67,13 +66,14 @@ class ClientTest {
         assertEquals(client.address, clientFromV1Bundle.address)
         assertEquals(
             client.privateKeyBundleV1?.identityKey,
-            clientFromV1Bundle.privateKeyBundleV1?.identityKey
+            clientFromV1Bundle.privateKeyBundleV1?.identityKey,
         )
         assertEquals(
             client.privateKeyBundleV1?.preKeysList,
-            clientFromV1Bundle.privateKeyBundleV1?.preKeysList
+            clientFromV1Bundle.privateKeyBundleV1?.preKeysList,
         )
     }
+
     @Test
     fun testCanMessage() {
         val fixtures = fixtures()
@@ -83,17 +83,19 @@ class ClientTest {
         assert(canMessage)
         assert(!cannotMessage)
     }
+
     @Test
     fun testPublicCanMessage() {
-        val aliceWallet = PrivateKeyBuilder()
+        val fixtures = fixtures()
+        val aliceWallet = fixtures.aliceClient
         val notOnNetwork = PrivateKeyBuilder()
         val identity = PrivateKeyBuilder().getPrivateKey()
-        val authorized = aliceWallet.createIdentity(identity)
+        val authorized = fixtures.aliceAccount.createIdentity(identity)
         val authToken = authorized.createAuthToken()
-        val api = GRPCApiClient(environment = XMTPEnvironment.DEV, secure = false)
+        val api = fixtures.aliceClient.apiClient
         api.setAuthToken(authToken)
 
-        val canMessage = Client.canMessage(aliceWallet.address, apiClient =  api)
+        val canMessage = Client.canMessage(aliceWallet.address, apiClient = api)
         val cannotMessage = Client.canMessage(notOnNetwork.address, apiClient = api)
         assert(canMessage)
         assert(!cannotMessage)

--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -84,14 +84,17 @@ class ClientTest {
         assert(!cannotMessage)
     }
     @Test
-    @Ignore("CI Issues")
     fun testPublicCanMessage() {
-        val fixtures = fixtures()
+        val aliceWallet = PrivateKeyBuilder()
         val notOnNetwork = PrivateKeyBuilder()
-        val clientOptions =
-            ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.LOCAL, isSecure = false, appVersion = "XMTPTest/v1.0.0"))
-        val canMessage = Client.canMessage(fixtures.bobClient.address, clientOptions)
-        val cannotMessage = Client.canMessage(notOnNetwork.address, clientOptions)
+        val identity = PrivateKeyBuilder().getPrivateKey()
+        val authorized = aliceWallet.createIdentity(identity)
+        val authToken = authorized.createAuthToken()
+        val api = GRPCApiClient(environment = XMTPEnvironment.DEV, secure = false)
+        api.setAuthToken(authToken)
+
+        val canMessage = Client.canMessage(aliceWallet.address, apiClient =  api)
+        val cannotMessage = Client.canMessage(notOnNetwork.address, apiClient = api)
         assert(canMessage)
         assert(!cannotMessage)
     }

--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -86,17 +86,20 @@ class ClientTest {
 
     @Test
     fun testPublicCanMessage() {
-        val fixtures = fixtures()
-        val aliceWallet = fixtures.aliceClient
+        val aliceWallet = PrivateKeyBuilder()
         val notOnNetwork = PrivateKeyBuilder()
-        val identity = PrivateKeyBuilder().getPrivateKey()
-        val authorized = fixtures.aliceAccount.createIdentity(identity)
-        val authToken = authorized.createAuthToken()
-        val api = fixtures.aliceClient.apiClient
-        api.setAuthToken(authToken)
+        val opts = ClientOptions(ClientOptions.Api(XMTPEnvironment.LOCAL, false))
+        val aliceClient = Client().create(aliceWallet, opts)
+        aliceClient.ensureUserContactPublished()
 
-        val canMessage = Client.canMessage(aliceWallet.address, apiClient = api)
-        val cannotMessage = Client.canMessage(notOnNetwork.address, apiClient = api)
+        val canMessage = Client.canMessage(
+            aliceWallet.address,
+            ClientOptions(ClientOptions.Api(XMTPEnvironment.LOCAL, false))
+        )
+        val cannotMessage = Client.canMessage(
+            notOnNetwork.address,
+        )
+
         assert(canMessage)
         assert(!cannotMessage)
     }

--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -92,13 +92,8 @@ class ClientTest {
         val aliceClient = Client().create(aliceWallet, opts)
         aliceClient.ensureUserContactPublished()
 
-        val canMessage = Client.canMessage(
-            aliceWallet.address,
-            ClientOptions(ClientOptions.Api(XMTPEnvironment.LOCAL, false))
-        )
-        val cannotMessage = Client.canMessage(
-            notOnNetwork.address,
-        )
+        val canMessage = Client.canMessage(aliceWallet.address, opts)
+        val cannotMessage = Client.canMessage(notOnNetwork.address, opts)
 
         assert(canMessage)
         assert(!cannotMessage)

--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -189,6 +189,7 @@ data class GRPCApiClient(
 
         return client.subscribe(request, headers)
     }
+
     override suspend fun subscribe2(request: Flow<SubscribeRequest>): Flow<Envelope> {
         val headers = Metadata()
 

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -114,10 +114,10 @@ class Client() {
                 )
             )
         }
-        fun canMessage(peerAddress: String, options: ClientOptions? = null): Boolean {
+        fun canMessage(peerAddress: String, options: ClientOptions? = null, apiClient: GRPCApiClient? = null): Boolean {
             val clientOptions = options ?: ClientOptions()
-            val apiClient = GRPCApiClient(environment = clientOptions.api.env, secure = clientOptions.api.isSecure)
-            return runBlocking { apiClient.queryTopic(Topic.contact(peerAddress)).envelopesList.size > 0 }
+            val api = apiClient ?: GRPCApiClient(environment = clientOptions.api.env, secure = clientOptions.api.isSecure)
+            return runBlocking { api.queryTopic(Topic.contact(peerAddress)).envelopesList.size > 0 }
         }
     }
 

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -114,10 +114,17 @@ class Client() {
                 )
             )
         }
-        fun canMessage(peerAddress: String, options: ClientOptions? = null, apiClient: ApiClient? = null): Boolean {
+
+        fun canMessage(peerAddress: String, options: ClientOptions? = null): Boolean {
             val clientOptions = options ?: ClientOptions()
-            val api = apiClient ?: GRPCApiClient(environment = clientOptions.api.env, secure = clientOptions.api.isSecure)
-            return runBlocking { api.queryTopic(Topic.contact(peerAddress)).envelopesList.size > 0 }
+            val api = GRPCApiClient(
+                environment = clientOptions.api.env,
+                secure = clientOptions.api.isSecure
+            )
+            return runBlocking {
+                val topics = api.queryTopic(Topic.contact(peerAddress)).envelopesList
+                topics.isNotEmpty()
+            }
         }
     }
 

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -114,7 +114,7 @@ class Client() {
                 )
             )
         }
-        fun canMessage(peerAddress: String, options: ClientOptions? = null, apiClient: GRPCApiClient? = null): Boolean {
+        fun canMessage(peerAddress: String, options: ClientOptions? = null, apiClient: ApiClient? = null): Boolean {
             val clientOptions = options ?: ClientOptions()
             val api = apiClient ?: GRPCApiClient(environment = clientOptions.api.env, secure = clientOptions.api.isSecure)
             return runBlocking { api.queryTopic(Topic.contact(peerAddress)).envelopesList.size > 0 }

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -114,6 +114,11 @@ class Client() {
                 )
             )
         }
+        fun canMessage(peerAddress: String, options: ClientOptions? = null): Boolean {
+            val clientOptions = options ?: ClientOptions()
+            val apiClient = GRPCApiClient(environment = clientOptions.api.env, secure = clientOptions.api.isSecure)
+            return runBlocking { apiClient.queryTopic(Topic.contact(peerAddress)).envelopesList.size > 0 }
+        }
     }
 
     constructor(


### PR DESCRIPTION
This PR exposes the `canMessage` method as requested in this [comment](https://github.com/xmtp/xmtp-react-native/issues/109#issuecomment-1719252634)