### PR TITLE
Expose consent entries

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -766,6 +766,7 @@ class ConversationTest {
         bobClient.contacts.refreshConsentList()
 
         val isDenied = bobConversation.consentState() == ConsentState.DENIED
+        assertEquals(bobClient.contacts.consentList.entries.size, 1)
         assertTrue(isDenied)
 
         val aliceConversation = aliceClient.conversations.list()[0]

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -40,7 +40,7 @@ data class ConsentListEntry(
 }
 
 class ConsentList(val client: Client) {
-    private val entries: MutableMap<String, ConsentState> = mutableMapOf()
+    val entries: MutableMap<String, ConsentState> = mutableMapOf()
     private val publicKey =
         client.privateKeyBundleV1.identityKey.publicKey.secp256K1Uncompressed.bytes
     private val privateKey = client.privateKeyBundleV1.identityKey.secp256K1.bytes


### PR DESCRIPTION
Expose the map of consent entries so integrators can get all the consent items at once to populate their databases.