### PR TITLE
Add Pagination to Consent Query

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -860,30 +860,4 @@ class ConversationTest {
         assertFalse(Topic.isValidTopic(directMessageV2))
         assertFalse(Topic.isValidTopic(preferenceList))
     }
-
-    @Test
-    fun testConsentWorksAcrossPagination() {
-        val privateKeyData = listOf(0x08, 0x36, 0x20, 0x0f, 0xfa, 0xfa, 0x17, 0xa3, 0xcb, 0x8b, 0x54, 0xf2, 0x2d, 0x6a, 0xfa, 0x60, 0xb1, 0x3d, 0xa4, 0x87, 0x26, 0x54, 0x32, 0x41, 0xad, 0xc5, 0xc2, 0x50, 0xdb, 0xb0, 0xe0, 0xcd)
-            .map { it.toByte() }
-            .toByteArray()
-        // Use hardcoded privateKey
-        val privateKey = PrivateKeyBuilder.buildFromPrivateKeyData(privateKeyData)
-        val privateKeyBuilder = PrivateKeyBuilder(privateKey)
-        val options = ClientOptions(api = ClientOptions.Api(XMTPEnvironment.DEV, isSecure = true))
-        val randomClient = Client().create(account = privateKeyBuilder, options = options)
-        val conversations = randomClient.conversations.list()
-        val addresses = conversations.map { it.peerAddress }
-
-        val firstHundred = addresses.take(100)
-        val lastHundred = addresses.takeLast(100)
-
-        randomClient.contacts.allow(firstHundred)
-        randomClient.contacts.deny(lastHundred)
-
-        randomClient.contacts.refreshConsentList()
-
-        randomClient.contacts.consentList.entries.size
-
-        assertEquals(200, randomClient.contacts.consentList.entries.size)
-    }
 }

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -1,6 +1,5 @@
 package org.xmtp.android.library
 
-import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.google.protobuf.kotlin.toByteString

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library
 
+import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.google.protobuf.kotlin.toByteString
@@ -858,5 +859,31 @@ class ConversationTest {
         assertFalse(Topic.isValidTopic(directMessageV1))
         assertFalse(Topic.isValidTopic(directMessageV2))
         assertFalse(Topic.isValidTopic(preferenceList))
+    }
+
+    @Test
+    fun testConsentWorksAcrossPagination() {
+        val privateKeyData = listOf(0x08, 0x36, 0x20, 0x0f, 0xfa, 0xfa, 0x17, 0xa3, 0xcb, 0x8b, 0x54, 0xf2, 0x2d, 0x6a, 0xfa, 0x60, 0xb1, 0x3d, 0xa4, 0x87, 0x26, 0x54, 0x32, 0x41, 0xad, 0xc5, 0xc2, 0x50, 0xdb, 0xb0, 0xe0, 0xcd)
+            .map { it.toByte() }
+            .toByteArray()
+        // Use hardcoded privateKey
+        val privateKey = PrivateKeyBuilder.buildFromPrivateKeyData(privateKeyData)
+        val privateKeyBuilder = PrivateKeyBuilder(privateKey)
+        val options = ClientOptions(api = ClientOptions.Api(XMTPEnvironment.DEV, isSecure = true))
+        val randomClient = Client().create(account = privateKeyBuilder, options = options)
+        val conversations = randomClient.conversations.list()
+        val addresses = conversations.map { it.peerAddress }
+
+        val firstHundred = addresses.take(100)
+        val lastHundred = addresses.takeLast(100)
+
+        randomClient.contacts.allow(firstHundred)
+        randomClient.contacts.deny(lastHundred)
+
+        randomClient.contacts.refreshConsentList()
+
+        randomClient.contacts.consentList.entries.size
+
+        assertEquals(200, randomClient.contacts.consentList.entries.size)
     }
 }

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -1,6 +1,5 @@
 package org.xmtp.android.library
 
-import android.util.Log
 import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.messages.ContactBundle
 import org.xmtp.android.library.messages.ContactBundleBuilder

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library
 
+import android.util.Log
 import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.messages.ContactBundle
 import org.xmtp.android.library.messages.ContactBundleBuilder
@@ -52,14 +53,13 @@ class ConsentList(val client: Client) {
 
     @OptIn(ExperimentalUnsignedTypes::class)
     suspend fun load(): ConsentList {
-        val envelopes = client.query(
-            Topic.preferenceList(identifier),
+        val envelopes = client.apiClient.envelopes(
+            Topic.preferenceList(identifier).description,
             Pagination(direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING)
         )
         val consentList = ConsentList(client)
         val preferences: MutableList<PrivatePreferencesAction> = mutableListOf()
-
-        for (envelope in envelopes.envelopesList) {
+        for (envelope in envelopes) {
             val payload = uniffi.xmtp_dh.userPreferencesDecrypt(
                 publicKey.toByteArray().toUByteArray().toList(),
                 privateKey.toByteArray().toUByteArray().toList(),


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-react-native/issues/197

Consent was erroring because it was only returning the first 100 entries from the network. Now we use the envelopes method that paginations all of the envelopes.