### PR TITLE
Invalid Signature Error

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/KeyUtil.kt
+++ b/library/src/main/java/org/xmtp/android/library/KeyUtil.kt
@@ -14,6 +14,10 @@ object KeyUtil {
             val newPublicKey = ByteArray(64)
             System.arraycopy(publicKey, publicKey.size - 64, newPublicKey, 0, 64)
             byteArrayOf(0x4.toByte()) + newPublicKey
+        } else if (publicKey.size < 64) {
+            val newPublicKey = ByteArray(64)
+            System.arraycopy(publicKey, 0, newPublicKey, 64 - publicKey.size, publicKey.size)
+            byteArrayOf(0x4.toByte()) + newPublicKey
         } else {
             byteArrayOf(0x4.toByte()) + publicKey
         }


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-react-native/issues/196

Sometimes when treating a public key as a number, for the purpose of doing math with it, and when you’re treating it as a fixed-size array of bytes, which is how you send it over the wire. In Kotlin it can remove the leading zeros making the array less than the required 64 bytes. This makes sure we are always sending a 64 byte array padding with zeros if smaller.
