### PR TITLE
fix: add catch to listBatchDecryptedMessages method

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -358,8 +358,13 @@ data class Conversations(
                                 Log.d(TAG, "discarding message, unknown conversation $envelope")
                                 return@mapNotNull null
                             }
-                            val msg = conversation.decrypt(envelope)
-                            msg
+                            try {
+                                val msg = conversation.decrypt(envelope)
+                                msg
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Error decrypting message: $envelope", e)
+                                null
+                            }
                         }
                     },
                 )

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -322,8 +322,13 @@ data class Conversations(
                                 Log.d(TAG, "discarding message, unknown conversation $envelope")
                                 return@mapNotNull null
                             }
-                            val msg = conversation.decodeOrNull(envelope)
-                            msg
+                            try {
+                                val msg = conversation.decodeOrNull(envelope)
+                                msg
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Error decrypting message: $envelope", e)
+                                null
+                            }
                         }
                     },
                 )

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -322,13 +322,8 @@ data class Conversations(
                                 Log.d(TAG, "discarding message, unknown conversation $envelope")
                                 return@mapNotNull null
                             }
-                            try {
-                                val msg = conversation.decodeOrNull(envelope)
-                                msg
-                            } catch (e: Exception) {
-                                Log.e(TAG, "Error decrypting message: $envelope", e)
-                                null
-                            }
+                            val msg = conversation.decodeOrNull(envelope)
+                            msg
                         }
                     },
                 )


### PR DESCRIPTION
Closes https://github.com/xmtp/xmtp-react-native/issues/218.

This update adds a try-catch block to the `listBatchDecryptedMessages` method, improving error handling.