### PR TITLE
Use latest validation service

### DIFF
--- a/dev/local/docker-compose.yml
+++ b/dev/local/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - db
 
   validation:
-    image: xmtp/mls-validation-service:latest
+    image: ghcr.io/xmtp/mls-validation-service:main
     platform: linux/amd64
 
   db:


### PR DESCRIPTION
## Summary

Updates the docker image for the validation service to the one hosted on GHCR, which will get the latest updates.