### PR TITLE
Allow LOCAL with a custom string.

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -90,7 +90,7 @@ data class GRPCApiClient(
 
     private val channel: ManagedChannel =
         Grpc.newChannelBuilderForAddress(
-            environment.rawValue,
+            environment.getValue(),
             5556,
             if (secure) {
                 TlsChannelCredentials.create()

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -2,7 +2,6 @@ package org.xmtp.android.library
 
 import android.content.Context
 import android.os.Build
-import android.os.Environment
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Log

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -2,6 +2,7 @@ package org.xmtp.android.library
 
 import android.content.Context
 import android.os.Build
+import android.os.Environment
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Log
@@ -66,7 +67,7 @@ data class ClientOptions(
     val enableAlphaMls: Boolean = false,
 ) {
     data class Api(
-        val env: XMTPEnvironment = XMTPEnvironment.DEV,
+        val env: XMTPEnvironment = XMTPEnvironment.LOCAL,
         val isSecure: Boolean = true,
         val appVersion: String? = null,
     )
@@ -323,7 +324,7 @@ class Client() {
 
                 createClient(
                     logger = logger,
-                    host = "http://10.0.2.2:5556",
+                    host = "http://${options.api.env.getValue()}:5556",
                     isSecure = false,
                     db = dbPath,
                     encryptionKey = retrievedKey.encoded,

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -67,7 +67,7 @@ data class ClientOptions(
     val enableAlphaMls: Boolean = false,
 ) {
     data class Api(
-        val env: XMTPEnvironment = XMTPEnvironment.LOCAL,
+        val env: XMTPEnvironment = XMTPEnvironment.DEV,
         val isSecure: Boolean = true,
         val appVersion: String? = null,
     )

--- a/library/src/main/java/org/xmtp/android/library/XMTPEnvironment.kt
+++ b/library/src/main/java/org/xmtp/android/library/XMTPEnvironment.kt
@@ -3,11 +3,27 @@ package org.xmtp.android.library
 enum class XMTPEnvironment(val rawValue: String) {
     DEV("dev.xmtp.network"),
     PRODUCTION("production.xmtp.network"),
-    LOCAL("10.0.2.2"),
-    ;
+    LOCAL("10.0.2.2") {
+        override fun withValue(value: String): XMTPEnvironment {
+            return LOCAL.apply { customValue = value }
+        }
+    };
+
+    private var customValue: String = ""
+
+    open fun withValue(value: String): XMTPEnvironment {
+        return this
+    }
 
     companion object {
-        operator fun invoke(rawValue: String) =
-            XMTPEnvironment.values().firstOrNull { it.rawValue == rawValue }
+        operator fun invoke(rawValue: String): XMTPEnvironment {
+            return XMTPEnvironment.values().firstOrNull { it.rawValue == rawValue }
+                ?: LOCAL.withValue(rawValue)
+        }
+    }
+
+    // This function returns the actual raw value for the enum, handling the CUSTOM case.
+    fun getValue(): String {
+        return if (this == LOCAL && customValue.isNotEmpty()) customValue else rawValue
     }
 }


### PR DESCRIPTION
You can call this now with `XMTPEnvironment.LOCAL.withValue("<IP ADDRESS>")`

Gives the ability to run a physical android app pointing at a local environment.