### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/setup-gradle@v3
       - name: Run build with Gradle Wrapper
         run: ./gradlew build
       - name: Bump version and push tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/setup-gradle@v3
       - name: Start Docker containers
         run: dev/up
       - name: Gradle Run Unit Tests
@@ -46,8 +44,8 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Start Docker containers
         run: dev/up
       - name: Gradle Run Integration Tests


### PR DESCRIPTION
The java 17 bump broke releases. This should hopefully fix it.

https://github.com/xmtp/xmtp-android/actions/runs/7792254501/job/21249903539