### PR TITLE
Set topic to convoId instead of message ID

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -121,7 +121,7 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
     fun decrypt(message: Message): DecryptedMessage {
         return DecryptedMessage(
             id = message.id.toHex(),
-            topic = message.id.toHex(),
+            topic = message.convoId.toHex(),
             encodedContent = message.decode().encodedContent,
             senderAddress = message.senderAddress,
             sentAt = Date()

--- a/library/src/main/java/org/xmtp/android/library/libxmtp/Message.kt
+++ b/library/src/main/java/org/xmtp/android/library/libxmtp/Message.kt
@@ -12,6 +12,9 @@ data class Message(val client: Client, private val libXMTPMessage: FfiMessage) {
     val id: ByteArray
         get() = libXMTPMessage.id
 
+    val convoId: ByteArray
+        get() = libXMTPMessage.convoId
+
     val senderAddress: String
         get() = libXMTPMessage.addrFrom
 


### PR DESCRIPTION
We need a way to correlate a message to the conversation it came from. In libxmtp, this is the `convoId` field.

In v2, it seems the `topic` was previously used for this purpose. This doesn't exist in v3, but I'll plumb it up to `convoId` for now.