### PR TITLE
Fix for R8 and missing classes in release build

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -31,7 +31,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/example/proguard-rules.pro
+++ b/example/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-dontwarn java.beans.ConstructorProperties
+-dontwarn java.beans.Transient


### PR DESCRIPTION
### Problem
In release version catching:
Missing classes detected while running R8
Missing class java.beans.ConstructorProperties (referenced from: void com.fasterxml.jackson.databind.ext.Java7SupportImpl.())
Missing class java.beans.Transient (referenced from: void com.fasterxml.jackson.databind.ext.Java7SupportImpl.())

Also there is a chat of discord with this issue -> https://discord.com/channels/831836269558235136/1200448147420348488

### Expectations
- Once you create a release build R8 is running and must pass without a problem