### PR TITLE
fix: senderHmac parameter in MessageV2Builder

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/messages/MessageV2.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/MessageV2.kt
@@ -25,7 +25,7 @@ class MessageV2Builder(val senderHmac: ByteArray? = null, val shouldPush: Boolea
         fun buildFromCipherText(
             headerBytes: ByteArray,
             ciphertext: CipherText?,
-            senderHmac: ByteArray?,
+            senderHmac: ByteArray,
             shouldPush: Boolean,
         ): MessageV2Builder {
             val messageBuilder = MessageV2Builder(senderHmac = senderHmac, shouldPush = shouldPush)
@@ -33,6 +33,7 @@ class MessageV2Builder(val senderHmac: ByteArray? = null, val shouldPush: Boolea
                 it.headerBytes = headerBytes.toByteString()
                 it.ciphertext = ciphertext
                 it.shouldPush = shouldPush
+                it.senderHmac = senderHmac.toByteString()
             }.build()
             return messageBuilder
         }


### PR DESCRIPTION
**Description:**
This pull request enhances the `MessageV2Builder` by incorporating the `senderHmac` attribute. Integrating this attribute ensures its availability following the message decoding process. 

[link to Slack thread ](https://xmtp-labs.slack.com/archives/C06D1LM24SH/p1710243487707519)