### PR TITLE
feat: Threading Improvements for Query Calls

### DIFF
--- a/example/src/main/java/org/xmtp/android/example/MainViewModel.kt
+++ b/example/src/main/java/org/xmtp/android/example/MainViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.xmtp.android.example.extension.flowWhileShared
 import org.xmtp.android.example.extension.stateFlow
 import org.xmtp.android.example.pushnotifications.PushNotificationTokenManager
@@ -70,7 +71,7 @@ class MainViewModel : ViewModel() {
 
     @WorkerThread
     private fun fetchMostRecentMessage(conversation: Conversation): DecodedMessage? {
-        return conversation.messages(limit = 1).firstOrNull()
+        return runBlocking { conversation.messages(limit = 1).firstOrNull() }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/example/src/main/java/org/xmtp/android/example/conversation/ConversationDetailViewModel.kt
+++ b/example/src/main/java/org/xmtp/android/example/conversation/ConversationDetailViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.xmtp.android.example.ClientManager
 import org.xmtp.android.example.extension.flowWhileShared
 import org.xmtp.android.example.extension.stateFlow
@@ -77,7 +78,12 @@ class ConversationDetailViewModel(private val savedStateHandle: SavedStateHandle
         stateFlow(viewModelScope, null) { subscriptionCount ->
             if (conversation == null) {
                 conversation =
-                    ClientManager.client.fetchConversation(conversationTopic, includeGroups = false)
+                    runBlocking {
+                        ClientManager.client.fetchConversation(
+                            conversationTopic,
+                            includeGroups = false
+                        )
+                    }
             }
             if (conversation != null) {
                 conversation!!.streamMessages()

--- a/example/src/main/java/org/xmtp/android/example/pushnotifications/PushNotificationsService.kt
+++ b/example/src/main/java/org/xmtp/android/example/pushnotifications/PushNotificationsService.kt
@@ -14,6 +14,7 @@ import com.google.firebase.messaging.RemoteMessage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.xmtp.android.example.ClientManager
 import org.xmtp.android.example.R
 import org.xmtp.android.example.conversation.ConversationDetailActivity
@@ -56,7 +57,8 @@ class PushNotificationsService : FirebaseMessagingService() {
         GlobalScope.launch(Dispatchers.Main) {
             ClientManager.createClient(keysData, applicationContext)
         }
-        val conversation = ClientManager.client.fetchConversation(topic, includeGroups = true)
+        val conversation =
+            runBlocking { ClientManager.client.fetchConversation(topic, includeGroups = true) }
         if (conversation == null) {
             Log.e(TAG, "No keys or conversation persisted")
             return

--- a/library/src/androidTest/java/org/xmtp/android/library/AttachmentTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/AttachmentTest.kt
@@ -35,7 +35,7 @@ class AttachmentTest {
                 options = SendOptions(contentType = ContentTypeAttachment),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         assertEquals(messages.size, 1)
         if (messages.size == 1) {
             val content: Attachment? = messages[0].content()

--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -148,11 +148,12 @@ class ClientTest {
                     appContext = context
                 )
             )
+
         runBlocking {
             client.conversations.newGroup(listOf(client2.address))
             client.conversations.syncGroups()
+            assertEquals(client.conversations.listGroups().size, 1)
         }
-        assertEquals(client.conversations.listGroups().size, 1)
 
         client.deleteLocalDatabase()
 
@@ -166,8 +167,10 @@ class ClientTest {
                 )
             )
 
-        runBlocking { client.conversations.syncGroups() }
-        assertEquals(client.conversations.listGroups().size, 0)
+        runBlocking {
+            client.conversations.syncGroups()
+            assertEquals(client.conversations.listGroups().size, 0)
+        }
     }
 
     @Test
@@ -209,7 +212,7 @@ class ClientTest {
         val notOnNetwork = PrivateKeyBuilder()
         val opts = ClientOptions(ClientOptions.Api(XMTPEnvironment.LOCAL, false))
         val aliceClient = Client().create(aliceWallet, opts)
-        aliceClient.ensureUserContactPublished()
+        runBlocking { aliceClient.ensureUserContactPublished() }
 
         val canMessage = Client.canMessage(aliceWallet.address, opts)
         val cannotMessage = Client.canMessage(notOnNetwork.address, opts)

--- a/library/src/androidTest/java/org/xmtp/android/library/CodecTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/CodecTest.kt
@@ -68,7 +68,7 @@ class CodecTest {
                 options = SendOptions(contentType = NumberCodec().contentType),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         assertEquals(messages.size, 1)
         if (messages.size == 1) {
             val content: Double? = messages[0].content()
@@ -93,7 +93,7 @@ class CodecTest {
                 options = SendOptions(contentType = CompositeCodec().contentType),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         val decoded: DecodedComposite? = messages[0].content()
         assertEquals("hiya", decoded?.content())
     }
@@ -121,7 +121,7 @@ class CodecTest {
                 options = SendOptions(contentType = CompositeCodec().contentType),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         val decoded: DecodedComposite? = messages[0].content()
         val part1 = decoded!!.parts[0]
         val part2 = decoded.parts[1].parts[0]
@@ -144,7 +144,7 @@ class CodecTest {
                 options = SendOptions(contentType = codec.contentType),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         assert(messages.isNotEmpty())
 
         val message = MessageV2Builder.buildEncode(

--- a/library/src/androidTest/java/org/xmtp/android/library/ContactsTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ContactsTest.kt
@@ -1,6 +1,7 @@
 package org.xmtp.android.library
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,7 +13,7 @@ class ContactsTest {
     @Test
     fun testNormalizesAddresses() {
         val fixtures = fixtures()
-        fixtures.bobClient.ensureUserContactPublished()
+        runBlocking { fixtures.bobClient.ensureUserContactPublished() }
         val bobAddressLowerCased = fixtures.bobClient.address.lowercase()
         val bobContact = fixtures.aliceClient.getUserContact(peerAddress = bobAddressLowerCased)
         assert(bobContact != null)
@@ -21,7 +22,7 @@ class ContactsTest {
     @Test
     fun testCanFindContact() {
         val fixtures = fixtures()
-        fixtures.bobClient.ensureUserContactPublished()
+        runBlocking { fixtures.bobClient.ensureUserContactPublished() }
         val contactBundle = fixtures.aliceClient.contacts.find(fixtures.bob.walletAddress)
         assertEquals(contactBundle?.walletAddress, fixtures.bob.walletAddress)
     }
@@ -29,7 +30,7 @@ class ContactsTest {
     @Test
     fun testCachesContacts() {
         val fixtures = fixtures()
-        fixtures.bobClient.ensureUserContactPublished()
+        runBlocking { fixtures.bobClient.ensureUserContactPublished() }
         // Look up the first time
         fixtures.aliceClient.contacts.find(fixtures.bob.walletAddress)
         fixtures.fakeApiClient.assertNoQuery {
@@ -48,7 +49,7 @@ class ContactsTest {
 
         assert(!result)
 
-        contacts.allow(listOf(fixtures.alice.walletAddress))
+        runBlocking { contacts.allow(listOf(fixtures.alice.walletAddress)) }
 
         result = contacts.isAllowed(fixtures.alice.walletAddress)
         assert(result)
@@ -63,7 +64,7 @@ class ContactsTest {
 
         assert(!result)
 
-        contacts.deny(listOf(fixtures.alice.walletAddress))
+        runBlocking { contacts.deny(listOf(fixtures.alice.walletAddress)) }
 
         result = contacts.isDenied(fixtures.alice.walletAddress)
         assert(result)

--- a/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
@@ -62,7 +62,7 @@ class GroupTest {
     fun testCanCreateAGroupWithDefaultPermissions() {
         val boGroup = runBlocking { boClient.conversations.newGroup(listOf(alix.walletAddress)) }
         runBlocking { alixClient.conversations.syncGroups() }
-        val alixGroup = alixClient.conversations.listGroups().first()
+        val alixGroup = runBlocking { alixClient.conversations.listGroups().first() }
         assert(boGroup.id.isNotEmpty())
         assert(alixGroup.id.isNotEmpty())
 
@@ -104,7 +104,7 @@ class GroupTest {
             )
         }
         runBlocking { alixClient.conversations.syncGroups() }
-        val alixGroup = alixClient.conversations.listGroups().first()
+        val alixGroup = runBlocking { alixClient.conversations.listGroups().first() }
         assert(boGroup.id.isNotEmpty())
         assert(alixGroup.id.isNotEmpty())
 
@@ -219,7 +219,7 @@ class GroupTest {
             )
         }
         runBlocking { alixClient.conversations.syncGroups() }
-        val group = alixClient.conversations.listGroups().first()
+        val group = runBlocking { alixClient.conversations.listGroups().first() }
         runBlocking { group.removeMembers(listOf(caro.walletAddress)) }
         assertEquals(
             group.memberAddresses().sorted(),
@@ -241,7 +241,7 @@ class GroupTest {
             )
         }
         runBlocking { caroClient.conversations.syncGroups() }
-        val caroGroup = caroClient.conversations.listGroups().first()
+        val caroGroup = runBlocking { caroClient.conversations.listGroups().first() }
         runBlocking { caroGroup.sync() }
         assert(caroGroup.isActive())
         assert(group.isActive())
@@ -259,7 +259,7 @@ class GroupTest {
             boClient.conversations.newGroup(listOf(alix.walletAddress))
             boClient.conversations.newGroup(listOf(caro.walletAddress))
         }
-        val groups = boClient.conversations.listGroups()
+        val groups = runBlocking { boClient.conversations.listGroups() }
         assertEquals(groups.size, 2)
     }
 
@@ -270,7 +270,7 @@ class GroupTest {
             boClient.conversations.newGroup(listOf(caro.walletAddress))
             boClient.conversations.newConversation(alix.walletAddress)
         }
-        val convos = boClient.conversations.list(includeGroups = true)
+        val convos = runBlocking { boClient.conversations.list(includeGroups = true) }
         assertEquals(convos.size, 3)
     }
 
@@ -319,7 +319,7 @@ class GroupTest {
         assertEquals(group.messages().size, 3)
 
         runBlocking { alixClient.conversations.syncGroups() }
-        val sameGroup = alixClient.conversations.listGroups().last()
+        val sameGroup = runBlocking { alixClient.conversations.listGroups().last() }
         runBlocking { sameGroup.sync() }
         assertEquals(sameGroup.messages().size, 2)
         assertEquals(sameGroup.messages().first().body, "gm")
@@ -515,7 +515,7 @@ class GroupTest {
         var result = boClient.contacts.isGroupAllowed(group.id)
         assert(result)
 
-        boClient.contacts.allowGroup(listOf(group.id))
+        runBlocking { boClient.contacts.allowGroup(listOf(group.id)) }
 
         result = boClient.contacts.isGroupAllowed(group.id)
         assert(result)
@@ -534,7 +534,7 @@ class GroupTest {
         var result = boClient.contacts.isGroupAllowed(group.id)
         assert(result)
 
-        boClient.contacts.denyGroup(listOf(group.id))
+        runBlocking { boClient.contacts.denyGroup(listOf(group.id)) }
 
         result = boClient.contacts.isGroupDenied(group.id)
         assert(result)

--- a/library/src/androidTest/java/org/xmtp/android/library/InvitationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/InvitationTest.kt
@@ -2,6 +2,7 @@ package org.xmtp.android.library
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.protobuf.kotlin.toByteString
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -52,10 +53,10 @@ class InvitationTest {
 
         val client = Client().create(account = PrivateKeyBuilder(key))
         Assert.assertEquals(client.apiClient.environment, XMTPEnvironment.DEV)
-        val conversations = client.conversations.list()
-        Assert.assertEquals(1, conversations.size)
-        val message = conversations[0].messages().firstOrNull()
-        Assert.assertEquals(message?.body, "hello")
+        val conversations = runBlocking { client.conversations.list() }
+        assertEquals(1, conversations.size)
+        val message = runBlocking { conversations[0].messages().firstOrNull() }
+        assertEquals(message?.body, "hello")
     }
 
     @Test

--- a/library/src/androidTest/java/org/xmtp/android/library/MessageTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/MessageTest.kt
@@ -162,9 +162,11 @@ class MessageTest {
 
         val client = Client().create(account = PrivateKeyBuilder(key))
         assertEquals(client.apiClient.environment, XMTPEnvironment.DEV)
-        val convo = client.conversations.list()[0]
-        val message = convo.messages()[0]
-        assertEquals("Test message", message.content())
+        runBlocking {
+            val convo = client.conversations.list()[0]
+            val message = convo.messages()[0]
+            assertEquals("Test message", message.content())
+        }
     }
 
     @Test
@@ -195,15 +197,15 @@ class MessageTest {
 
         val client = Client().create(account = PrivateKeyBuilder(key))
         assertEquals(client.apiClient.environment, XMTPEnvironment.DEV)
-        val convo = client.conversations.list()[0]
         runBlocking {
+            val convo = client.conversations.list()[0]
             convo.send(
                 text = "hello deflate from kotlin again",
                 SendOptions(compression = EncodedContentCompression.DEFLATE),
             )
+            val message = convo.messages().lastOrNull()!!
+            assertEquals("hello deflate from kotlin again", message.content())
         }
-        val message = convo.messages().lastOrNull()!!
-        assertEquals("hello deflate from kotlin again", message.content())
     }
 
     @Test
@@ -231,7 +233,7 @@ class MessageTest {
             }.build()
         }.build()
         val client = Client().create(account = PrivateKeyBuilder(key))
-        val conversations = client.conversations.list()
+        val conversations = runBlocking { client.conversations.list() }
         assertEquals(201, conversations.size)
     }
 
@@ -245,7 +247,7 @@ class MessageTest {
             sentAt = Date(),
         )
         runBlocking { convo.send(text = "hello from kotlin") }
-        val messages = convo.messages()
+        val messages = runBlocking { convo.messages() }
         assertEquals(1, messages.size)
         assertEquals("hello from kotlin", messages[0].body)
         assertEquals(convo.topic.description, messages[0].topic)
@@ -263,7 +265,7 @@ class MessageTest {
         }
 
         runBlocking { convo.send(content = "hello from kotlin") }
-        val messages = convo.messages()
+        val messages = runBlocking { convo.messages() }
         assertEquals(1, messages.size)
         assertEquals("hello from kotlin", messages[0].body)
         assertEquals(convo.topic, messages[0].topic)

--- a/library/src/androidTest/java/org/xmtp/android/library/ReactionTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ReactionTest.kt
@@ -74,7 +74,7 @@ class ReactionTest {
 
         runBlocking { aliceConversation.send(text = "hey alice 2 bob") }
 
-        val messageToReact = aliceConversation.messages()[0]
+        val messageToReact = runBlocking { aliceConversation.messages()[0] }
 
         val attachment = Reaction(
             reference = messageToReact.id,
@@ -89,7 +89,7 @@ class ReactionTest {
                 options = SendOptions(contentType = ContentTypeReaction),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         assertEquals(messages.size, 2)
         if (messages.size == 2) {
             val content: Reaction? = messages.first().content()
@@ -112,7 +112,7 @@ class ReactionTest {
 
         runBlocking { aliceConversation.send(text = "hey alice 2 bob") }
 
-        val messageToReact = aliceConversation.messages()[0]
+        val messageToReact = runBlocking { aliceConversation.messages()[0] }
 
         val attachment = Reaction(
             reference = messageToReact.id,
@@ -127,7 +127,7 @@ class ReactionTest {
                 options = SendOptions(contentType = ContentTypeReaction),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         assertEquals(messages.size, 2)
 
         val message = MessageV2Builder.buildEncode(

--- a/library/src/androidTest/java/org/xmtp/android/library/ReadReceiptTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ReadReceiptTest.kt
@@ -33,7 +33,7 @@ class ReadReceiptTest {
                 options = SendOptions(contentType = ContentTypeReadReceipt),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         assertEquals(messages.size, 2)
         if (messages.size == 2) {
             val contentType: String = messages.first().encodedContent.type.typeId

--- a/library/src/androidTest/java/org/xmtp/android/library/ReplyTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ReplyTest.kt
@@ -26,7 +26,7 @@ class ReplyTest {
 
         runBlocking { aliceConversation.send(text = "hey alice 2 bob") }
 
-        val messageToReact = aliceConversation.messages()[0]
+        val messageToReact = runBlocking { aliceConversation.messages()[0] }
 
         val attachment = Reply(
             reference = messageToReact.id,
@@ -40,7 +40,7 @@ class ReplyTest {
                 options = SendOptions(contentType = ContentTypeReply),
             )
         }
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         assertEquals(messages.size, 2)
         if (messages.size == 2) {
             val content: Reply? = messages.first().content()

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -448,7 +448,7 @@ class Client() {
         return null
     }
 
-    fun publishUserContact(legacy: Boolean = false) {
+    suspend fun publishUserContact(legacy: Boolean = false) {
         val envelopes: MutableList<MessageApiOuterClass.Envelope> = mutableListOf()
         if (legacy) {
             val contactBundle = ContactBundle.newBuilder().also {
@@ -484,7 +484,7 @@ class Client() {
             message = contactBundle.toByteString()
         }.build()
         envelopes.add(envelope)
-        runBlocking { publish(envelopes = envelopes) }
+        publish(envelopes = envelopes)
     }
 
     fun getUserContact(peerAddress: String): ContactBundle? {
@@ -525,7 +525,7 @@ class Client() {
         return apiClient.publish(envelopes = envelopes)
     }
 
-    fun ensureUserContactPublished() {
+    suspend fun ensureUserContactPublished() {
         val contact = getUserContact(peerAddress = address)
         if (contact != null && keys.getPublicKeyBundle() == contact.v2.keyBundle) {
             return

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -506,7 +506,7 @@ class Client() {
         return apiClient.subscribe(request = request)
     }
 
-    fun fetchConversation(topic: String?, includeGroups: Boolean = false): Conversation? {
+    suspend fun fetchConversation(topic: String?, includeGroups: Boolean = false): Conversation? {
         if (topic.isNullOrBlank()) return null
         return conversations.list(includeGroups = includeGroups).firstOrNull {
             it.topic == topic

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -101,7 +101,7 @@ class ConsentList(val client: Client) {
         return consentList
     }
 
-    fun publish(entry: ConsentListEntry) {
+    suspend fun publish(entry: ConsentListEntry) {
         val payload =
             PrivatePreferencesAction.newBuilder().also {
                 when (entry.entryType) {
@@ -152,7 +152,7 @@ class ConsentList(val client: Client) {
                 ByteArray(message.size) { message[it] },
             )
 
-        runBlocking { client.publish(listOf(envelope)) }
+        client.publish(listOf(envelope))
     }
 
     fun allow(address: String): ConsentListEntry {
@@ -210,25 +210,25 @@ data class Contacts(
         return consentList
     }
 
-    fun allow(addresses: List<String>) {
+    suspend fun allow(addresses: List<String>) {
         for (address in addresses) {
             ConsentList(client).publish(consentList.allow(address))
         }
     }
 
-    fun deny(addresses: List<String>) {
+    suspend fun deny(addresses: List<String>) {
         for (address in addresses) {
             ConsentList(client).publish(consentList.deny(address))
         }
     }
 
-    fun allowGroup(groupIds: List<ByteArray>) {
+    suspend fun allowGroup(groupIds: List<ByteArray>) {
         for (id in groupIds) {
             ConsentList(client).publish(consentList.allowGroup(id))
         }
     }
 
-    fun denyGroup(groupIds: List<ByteArray>) {
+    suspend fun denyGroup(groupIds: List<ByteArray>) {
         for (id in groupIds) {
             ConsentList(client).publish(consentList.denyGroup(id))
         }

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -229,7 +229,7 @@ sealed class Conversation {
      * If [limit] is specified then results are pulled in pages of that size.
      * If [direction] is specified then that will control the sort order of te messages.
      */
-    fun messages(
+    suspend fun messages(
         limit: Int? = null,
         before: Date? = null,
         after: Date? = null,
@@ -262,7 +262,7 @@ sealed class Conversation {
         }
     }
 
-    fun decryptedMessages(
+    suspend fun decryptedMessages(
         limit: Int? = null,
         before: Date? = null,
         after: Date? = null,

--- a/library/src/main/java/org/xmtp/android/library/ConversationV1.kt
+++ b/library/src/main/java/org/xmtp/android/library/ConversationV1.kt
@@ -3,7 +3,6 @@ package org.xmtp.android.library
 import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.Hash
 import org.xmtp.android.library.codecs.ContentCodec
 import org.xmtp.android.library.codecs.EncodedContent
@@ -60,7 +59,7 @@ data class ConversationV1(
      * If [direction] is specified then that will control the sort order of te messages.
      * @see Conversation.messages
      */
-    fun messages(
+    suspend fun messages(
         limit: Int? = null,
         before: Date? = null,
         after: Date? = null,
@@ -68,9 +67,7 @@ data class ConversationV1(
     ): List<DecodedMessage> {
         val pagination =
             Pagination(limit = limit, before = before, after = after, direction = direction)
-        val result = runBlocking {
-            client.apiClient.envelopes(topic = topic.description, pagination = pagination)
-        }
+        val result = client.apiClient.envelopes(topic = topic.description, pagination = pagination)
 
         return result.mapNotNull { envelope ->
             decodeOrNull(envelope = envelope)
@@ -90,7 +87,7 @@ data class ConversationV1(
      * If [limit] is specified then results are pulled in pages of that size.
      * If [direction] is specified then that will control the sort order of te messages.
      */
-    fun decryptedMessages(
+    suspend fun decryptedMessages(
         limit: Int? = null,
         before: Date? = null,
         after: Date? = null,
@@ -99,12 +96,11 @@ data class ConversationV1(
         val pagination =
             Pagination(limit = limit, before = before, after = after, direction = direction)
 
-        val envelopes = runBlocking {
+        val envelopes =
             client.apiClient.envelopes(
                 topic = Topic.directMessageV1(client.address, peerAddress).description,
                 pagination = pagination,
             )
-        }
 
         return envelopes.map { decrypt(it) }
     }

--- a/library/src/main/java/org/xmtp/android/library/ConversationV2.kt
+++ b/library/src/main/java/org/xmtp/android/library/ConversationV2.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.Hash
 import org.xmtp.android.library.codecs.ContentCodec
 import org.xmtp.android.library.codecs.EncodedContent
@@ -73,7 +72,7 @@ data class ConversationV2(
      * If [direction] is specified then that will control the sort order of te messages.
      * @see Conversation.messages
      */
-    fun messages(
+    suspend fun messages(
         limit: Int? = null,
         before: Date? = null,
         after: Date? = null,
@@ -81,12 +80,11 @@ data class ConversationV2(
     ): List<DecodedMessage> {
         val pagination =
             Pagination(limit = limit, before = before, after = after, direction = direction)
-        val result = runBlocking {
+        val result =
             client.apiClient.envelopes(
                 topic = topic,
                 pagination = pagination,
             )
-        }
 
         return result.mapNotNull { envelope ->
             decodeEnvelopeOrNull(envelope)
@@ -106,7 +104,7 @@ data class ConversationV2(
      * If [limit] is specified then results are pulled in pages of that size.
      * If [direction] is specified then that will control the sort order of te messages.
      */
-    fun decryptedMessages(
+    suspend fun decryptedMessages(
         limit: Int? = null,
         before: Date? = null,
         after: Date? = null,
@@ -114,7 +112,7 @@ data class ConversationV2(
     ): List<DecryptedMessage> {
         val pagination =
             Pagination(limit = limit, before = before, after = after, direction = direction)
-        val envelopes = runBlocking { client.apiClient.envelopes(topic, pagination) }
+        val envelopes = client.apiClient.envelopes(topic, pagination)
 
         return envelopes.map { envelope ->
             decrypt(envelope)

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -3,7 +3,6 @@ package org.xmtp.android.library
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.codecs.ContentCodec
 import org.xmtp.android.library.codecs.EncodedContent
 import org.xmtp.android.library.codecs.compress
@@ -84,20 +83,18 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
         after: Date? = null,
         direction: PagingInfoSortDirection = MessageApiOuterClass.SortDirection.SORT_DIRECTION_DESCENDING,
     ): List<DecodedMessage> {
-        return runBlocking {
-            val messages = libXMTPGroup.findMessages(
-                opts = FfiListMessagesOptions(
-                    sentBeforeNs = before?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
-                    sentAfterNs = after?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
-                    limit = limit?.toLong()
-                )
-            ).map {
-                Message(client, it).decode()
-            }
-            when (direction) {
-                MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING -> messages
-                else -> messages.reversed()
-            }
+        val messages = libXMTPGroup.findMessages(
+            opts = FfiListMessagesOptions(
+                sentBeforeNs = before?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
+                sentAfterNs = after?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
+                limit = limit?.toLong()
+            )
+        ).map {
+            Message(client, it).decode()
+        }
+        return when (direction) {
+            MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING -> messages
+            else -> messages.reversed()
         }
     }
 
@@ -107,20 +104,18 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
         after: Date? = null,
         direction: PagingInfoSortDirection = MessageApiOuterClass.SortDirection.SORT_DIRECTION_DESCENDING,
     ): List<DecryptedMessage> {
-        return runBlocking {
-            val messages = libXMTPGroup.findMessages(
-                opts = FfiListMessagesOptions(
-                    sentBeforeNs = before?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
-                    sentAfterNs = after?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
-                    limit = limit?.toLong()
-                )
-            ).map {
-                Message(client, it).decrypt()
-            }
-            when (direction) {
-                MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING -> messages
-                else -> messages.reversed()
-            }
+        val messages = libXMTPGroup.findMessages(
+            opts = FfiListMessagesOptions(
+                sentBeforeNs = before?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
+                sentAfterNs = after?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
+                limit = limit?.toLong()
+            )
+        ).map {
+            Message(client, it).decrypt()
+        }
+        return when (direction) {
+            MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING -> messages
+            else -> messages.reversed()
         }
     }
 
@@ -157,9 +152,7 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
     }
 
     fun memberAddresses(): List<String> {
-        return runBlocking {
-            libXMTPGroup.listMembers().map { it.accountAddress }
-        }
+        return libXMTPGroup.listMembers().map { it.accountAddress }
     }
 
     fun peerAddresses(): List<String> {

--- a/library/src/test/java/org/xmtp/android/library/RemoteAttachmentTest.kt
+++ b/library/src/test/java/org/xmtp/android/library/RemoteAttachmentTest.kt
@@ -79,7 +79,7 @@ class RemoteAttachmentTest {
             )
         }
 
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         Assert.assertEquals(messages.size, 1)
 
         if (messages.size == 1) {
@@ -161,7 +161,7 @@ class RemoteAttachmentTest {
             )
         }
 
-        val messages = aliceConversation.messages()
+        val messages = runBlocking { aliceConversation.messages() }
         Assert.assertEquals(messages.size, 1)
 
         // Tamper with the payload


### PR DESCRIPTION
This is the final piece in cleaning up the thread safety of the SDK.

This makes sure all query calls are correctly suspend functions. And cleans up one lingering place for publish.