### PR TITLE
Cache Consent Records

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -60,10 +60,10 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.47.0"
+            artifact = "io.grpc:protoc-gen-grpc-java:1.62.2"
         }
         grpckt {
-            artifact = "io.grpc:protoc-gen-grpc-kotlin:1.3.0:jdk8@jar"
+            artifact = "io.grpc:protoc-gen-grpc-kotlin:1.4.1:jdk8@jar"
         }
     }
     generateProtoTasks {
@@ -79,9 +79,9 @@ protobuf {
 
 dependencies {
     implementation 'com.google.crypto.tink:tink-android:1.8.0'
-    implementation 'io.grpc:grpc-kotlin-stub:1.3.0'
-    implementation 'io.grpc:grpc-okhttp:1.51.1'
-    implementation 'io.grpc:grpc-protobuf-lite:1.51.0'
+    implementation 'io.grpc:grpc-kotlin-stub:1.4.1'
+    implementation 'io.grpc:grpc-okhttp:1.62.2'
+    implementation 'io.grpc:grpc-protobuf-lite:1.62.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
     implementation 'org.web3j:crypto:5.0.0'
     implementation "net.java.dev.jna:jna:5.13.0@aar"

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -799,9 +799,10 @@ class ConversationTest {
         assertTrue(isAllowed)
         assertTrue(bobClient.contacts.isAllowed(alice.walletAddress))
 
-        runBlocking { bobClient.contacts.deny(listOf(alice.walletAddress)) }
-        bobClient.contacts.refreshConsentList()
-
+        runBlocking {
+            bobClient.contacts.deny(listOf(alice.walletAddress))
+            bobClient.contacts.refreshConsentList()
+        }
         val isDenied = bobConversation.consentState() == ConsentState.DENIED
         assertEquals(bobClient.contacts.consentList.entries.size, 1)
         assertTrue(isDenied)
@@ -820,7 +821,7 @@ class ConversationTest {
         val aliceClient2 = Client().create(aliceWallet)
         val aliceConversation2 = runBlocking { aliceClient2.conversations.list()[0] }
 
-        aliceClient2.contacts.refreshConsentList()
+        runBlocking { aliceClient2.contacts.refreshConsentList() }
 
         // Allow state should sync across clients
         val isBobAllowed2 = aliceConversation2.consentState() == ConsentState.ALLOWED
@@ -843,8 +844,10 @@ class ConversationTest {
         // Conversations you receive should start as unknown
         assertTrue(isUnknown)
 
-        runBlocking { aliceConversation.send(content = "hey bob") }
-        aliceClient.contacts.refreshConsentList()
+        runBlocking {
+            aliceConversation.send(content = "hey bob")
+            aliceClient.contacts.refreshConsentList()
+        }
         val isNowAllowed = aliceConversation.consentState() == ConsentState.ALLOWED
 
         // Conversations you send a message to get marked as allowed

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -519,13 +519,7 @@ class ConversationTest {
                 ),
             )
         }
-        val isSteveOrBobConversation = { topic: String ->
-            (topic.lowercase() == steveConversation.topic.lowercase() || topic.lowercase() == bobConversation.topic.lowercase())
-        }
         assertEquals(3, messages.size)
-        assertTrue(isSteveOrBobConversation(messages[0].topic))
-        assertTrue(isSteveOrBobConversation(messages[1].topic))
-        assertTrue(isSteveOrBobConversation(messages[2].topic))
     }
 
     @Test

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -854,7 +854,7 @@ class ConversationTest {
             val bobConversation = bobClient.conversations.newConversation(alice.walletAddress)
             val caroConversation =
                 bobClient.conversations.newConversation(fixtures.caro.walletAddress)
-
+            bobClient.contacts.refreshConsentList()
             assertEquals(bobClient.contacts.consentList.entries.size, 2)
             assertTrue(bobConversation.consentState() == ConsentState.ALLOWED)
             assertTrue(caroConversation.consentState() == ConsentState.ALLOWED)

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -849,6 +849,23 @@ class ConversationTest {
     }
 
     @Test
+    fun testCanPublishMultipleAddressConsentState() {
+        runBlocking {
+            val bobConversation = bobClient.conversations.newConversation(alice.walletAddress)
+            val caroConversation =
+                bobClient.conversations.newConversation(fixtures.caro.walletAddress)
+
+            assertEquals(bobClient.contacts.consentList.entries.size, 2)
+            assertTrue(bobConversation.consentState() == ConsentState.ALLOWED)
+            assertTrue(caroConversation.consentState() == ConsentState.ALLOWED)
+            bobClient.contacts.deny(listOf(alice.walletAddress, fixtures.caro.walletAddress))
+            assertEquals(bobClient.contacts.consentList.entries.size, 2)
+            assertTrue(bobConversation.consentState() == ConsentState.DENIED)
+            assertTrue(caroConversation.consentState() == ConsentState.DENIED)
+        }
+    }
+
+    @Test
     fun testCanValidateTopicsInsideConversation() {
         val validId = "sdfsadf095b97a9284dcd82b2274856ccac8a21de57bebe34e7f9eeb855fb21126d3b8f"
 

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -8,6 +8,7 @@ import org.xmtp.android.library.messages.EnvelopeBuilder
 import org.xmtp.android.library.messages.Pagination
 import org.xmtp.android.library.messages.Topic
 import org.xmtp.android.library.messages.walletAddress
+import org.xmtp.proto.message.api.v1.MessageApiOuterClass
 import org.xmtp.proto.message.contents.PrivatePreferences.PrivatePreferencesAction
 import java.util.Date
 
@@ -68,9 +69,10 @@ class ConsentList(
             client.apiClient.envelopes(
                 Topic.preferenceList(identifier).description,
                 Pagination(
-                    after = lastFetched
+                    after = lastFetched,
+                    direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING
                 ),
-            ).reversed()
+            )
         lastFetched = newDate
         val preferences: MutableList<PrivatePreferencesAction> = mutableListOf()
         for (envelope in envelopes) {

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -8,7 +8,6 @@ import org.xmtp.android.library.messages.EnvelopeBuilder
 import org.xmtp.android.library.messages.Pagination
 import org.xmtp.android.library.messages.Topic
 import org.xmtp.android.library.messages.walletAddress
-import org.xmtp.proto.message.api.v1.MessageApiOuterClass
 import org.xmtp.proto.message.contents.PrivatePreferences.PrivatePreferencesAction
 import java.util.Date
 

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -69,7 +69,7 @@ class ConsentList(
             client.apiClient.envelopes(
                 Topic.preferenceList(identifier).description,
                 Pagination(
-                    before = lastFetched,
+                    after = lastFetched,
                     direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING
                 ),
             )

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -69,10 +69,9 @@ class ConsentList(
             client.apiClient.envelopes(
                 Topic.preferenceList(identifier).description,
                 Pagination(
-                    after = lastFetched,
-                    direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING
+                    after = lastFetched
                 ),
-            )
+            ).reversed()
         lastFetched = newDate
         val preferences: MutableList<PrivatePreferencesAction> = mutableListOf()
         for (envelope in envelopes) {


### PR DESCRIPTION
Adds caching to our consent records and fixes a threading issue.

On main:
```
Loaded 1102 consent entries in 9.039s
Second time loaded 1102 consent entries in 8.929s
```

On this branch:
```
Loaded 1102 consent entries in 9.342s
Second time loaded 1102 consent entries in 0.091s
```