### PR TITLE
Bump consent pagination

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -855,6 +855,7 @@ class ConversationTest {
             val caroConversation =
                 bobClient.conversations.newConversation(fixtures.caro.walletAddress)
             bobClient.contacts.refreshConsentList()
+            Thread.sleep(1000)
             assertEquals(bobClient.contacts.consentList.entries.size, 2)
             assertTrue(bobConversation.consentState() == ConsentState.ALLOWED)
             assertTrue(caroConversation.consentState() == ConsentState.ALLOWED)

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library
 
+import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.google.protobuf.kotlin.toByteString
@@ -909,5 +910,31 @@ class ConversationTest {
         assertFalse(Topic.isValidTopic(directMessageV1))
         assertFalse(Topic.isValidTopic(directMessageV2))
         assertFalse(Topic.isValidTopic(preferenceList))
+    }
+
+    @Test
+    fun testBigWallet() {
+        val privateKeyData = listOf(0x08, 0x36, 0x20, 0x0f, 0xfa, 0xfa, 0x17, 0xa3, 0xcb, 0x8b, 0x54, 0xf2, 0x2d, 0x6a, 0xfa, 0x60, 0xb1, 0x3d, 0xa4, 0x87, 0x26, 0x54, 0x32, 0x41, 0xad, 0xc5, 0xc2, 0x50, 0xdb, 0xb0, 0xe0, 0xcd)
+            .map { it.toByte() }
+            .toByteArray()
+        // Use hardcoded privateKey
+        val privateKey = PrivateKeyBuilder.buildFromPrivateKeyData(privateKeyData)
+        val privateKeyBuilder = PrivateKeyBuilder(privateKey)
+        val options =
+            ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.DEV))
+        val client = Client().create(account = privateKeyBuilder, options = options)
+
+        runBlocking {
+            val start = Date()
+            val consentList = client.contacts.refreshConsentList()
+            val end = Date()
+            Log.d("LOPI", "Loaded ${consentList.entries.size} consent entries in ${(end.time - start.time) / 1000.0}s")
+
+
+            val start2 = Date()
+            val consentList2 = client.contacts.refreshConsentList()
+            val end2 = Date()
+            Log.d("LOPI", "Second time loaded ${consentList2.entries.size} consent entries in ${(end2.time - start2.time) / 1000.0}s")
+        }
     }
 }

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -1,6 +1,5 @@
 package org.xmtp.android.library
 
-import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.google.protobuf.kotlin.toByteString
@@ -910,31 +909,5 @@ class ConversationTest {
         assertFalse(Topic.isValidTopic(directMessageV1))
         assertFalse(Topic.isValidTopic(directMessageV2))
         assertFalse(Topic.isValidTopic(preferenceList))
-    }
-
-    @Test
-    fun testBigWallet() {
-        val privateKeyData = listOf(0x08, 0x36, 0x20, 0x0f, 0xfa, 0xfa, 0x17, 0xa3, 0xcb, 0x8b, 0x54, 0xf2, 0x2d, 0x6a, 0xfa, 0x60, 0xb1, 0x3d, 0xa4, 0x87, 0x26, 0x54, 0x32, 0x41, 0xad, 0xc5, 0xc2, 0x50, 0xdb, 0xb0, 0xe0, 0xcd)
-            .map { it.toByte() }
-            .toByteArray()
-        // Use hardcoded privateKey
-        val privateKey = PrivateKeyBuilder.buildFromPrivateKeyData(privateKeyData)
-        val privateKeyBuilder = PrivateKeyBuilder(privateKey)
-        val options =
-            ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.DEV))
-        val client = Client().create(account = privateKeyBuilder, options = options)
-
-        runBlocking {
-            val start = Date()
-            val consentList = client.contacts.refreshConsentList()
-            val end = Date()
-            Log.d("LOPI", "Loaded ${consentList.entries.size} consent entries in ${(end.time - start.time) / 1000.0}s")
-
-
-            val start2 = Date()
-            val consentList2 = client.contacts.refreshConsentList()
-            val end2 = Date()
-            Log.d("LOPI", "Second time loaded ${consentList2.entries.size} consent entries in ${(end2.time - start2.time) / 1000.0}s")
-        }
     }
 }

--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -129,16 +129,25 @@ data class GRPCApiClient(
      * It yields all the envelopes in the query using the paging info
      * from the prior response to fetch the next page.
      */
-    override suspend fun envelopes(topic: String, pagination: Pagination?): List<Envelope> {
+    override suspend fun envelopes(
+        topic: String,
+        pagination: Pagination?,
+    ): List<Envelope> {
         var envelopes: MutableList<Envelope> = mutableListOf()
         var hasNextPage = true
         var cursor: Cursor? = null
         while (hasNextPage) {
-            val response = query(topic = topic, pagination = pagination, cursor = cursor)
+            val response =
+                query(topic = topic, pagination = pagination, cursor = cursor)
             envelopes.addAll(response.envelopesList)
             cursor = response.pagingInfo.cursor
             hasNextPage = response.envelopesList.isNotEmpty() && response.pagingInfo.hasCursor()
+            if (pagination?.limit != null && pagination.limit <= 100 && envelopes.size >= pagination.limit) {
+                envelopes = envelopes.take(pagination.limit).toMutableList()
+                break
+            }
         }
+
         return envelopes
     }
 

--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -138,10 +138,6 @@ data class GRPCApiClient(
             envelopes.addAll(response.envelopesList)
             cursor = response.pagingInfo.cursor
             hasNextPage = response.envelopesList.isNotEmpty() && response.pagingInfo.hasCursor()
-            if (pagination?.limit != null && envelopes.size >= pagination.limit) {
-                envelopes = envelopes.take(pagination.limit).toMutableList()
-                break
-            }
         }
         return envelopes
     }

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -1,6 +1,5 @@
 package org.xmtp.android.library
 
-import android.util.Log
 import com.google.protobuf.kotlin.toByteStringUtf8
 import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.messages.ContactBundle
@@ -66,7 +65,6 @@ class ConsentList(
     @OptIn(ExperimentalUnsignedTypes::class)
     suspend fun load(): List<ConsentListEntry> {
         val newDate = Date()
-        val start = Date()
         val envelopes =
             client.apiClient.envelopes(
                 Topic.preferenceList(identifier).description,
@@ -76,8 +74,6 @@ class ConsentList(
                     limit = 500
                 ),
             )
-        val end = Date()
-        Log.d("LOPI", "Loaded ${envelopes.size} consent envelopes in ${(end.time - start.time) / 1000.0}s")
 
         lastFetched = newDate
         val preferences: MutableList<PrivatePreferencesAction> = mutableListOf()

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library
 
+import android.util.Log
 import com.google.protobuf.kotlin.toByteStringUtf8
 import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.messages.ContactBundle
@@ -65,6 +66,7 @@ class ConsentList(
     @OptIn(ExperimentalUnsignedTypes::class)
     suspend fun load(): List<ConsentListEntry> {
         val newDate = Date()
+        val start = Date()
         val envelopes =
             client.apiClient.envelopes(
                 Topic.preferenceList(identifier).description,
@@ -74,6 +76,9 @@ class ConsentList(
                     limit = 500
                 ),
             )
+        val end = Date()
+        Log.d("LOPI", "Loaded ${envelopes.size} consent envelopes in ${(end.time - start.time) / 1000.0}s")
+
         lastFetched = newDate
         val preferences: MutableList<PrivatePreferencesAction> = mutableListOf()
         for (envelope in envelopes) {

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -70,7 +70,8 @@ class ConsentList(
                 Topic.preferenceList(identifier).description,
                 Pagination(
                     after = lastFetched,
-                    direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING
+                    direction = MessageApiOuterClass.SortDirection.SORT_DIRECTION_ASCENDING,
+                    limit = 500
                 ),
             )
         lastFetched = newDate

--- a/library/src/main/java/org/xmtp/android/library/messages/PagingInfo.kt
+++ b/library/src/main/java/org/xmtp/android/library/messages/PagingInfo.kt
@@ -16,35 +16,13 @@ data class Pagination(
 ) {
     val pagingInfo: PagingInfo
         get() {
-            return PagingInfo.newBuilder().also {
-                if (limit != null) {
-                    it.limit = limit
+            return PagingInfo.newBuilder().also { page ->
+                limit?.let {
+                    page.limit = it
                 }
                 if (direction != null) {
-                    it.direction = direction
+                    page.direction = direction
                 }
             }.build()
         }
-}
-
-class PagingInfoBuilder {
-    companion object {
-        fun buildFromPagingInfo(
-            limit: Int? = null,
-            cursor: PagingInfoCursor? = null,
-            direction: PagingInfoSortDirection? = null,
-        ): PagingInfo {
-            return PagingInfo.newBuilder().also {
-                if (limit != null) {
-                    it.limit = limit
-                }
-                if (cursor != null) {
-                    it.cursor = cursor
-                }
-                if (direction != null) {
-                    it.direction = direction
-                }
-            }.build()
-        }
-    }
 }


### PR DESCRIPTION
This bumps the consent record pagination size to 500 instead of the previous 100. Should help with performance of the subscribe feature.

Previously
```
Loaded 7561 consent envelopes in 8.542s
Loaded 1102 consent entries in 2.429s
Second time loaded 0 consent envelopes in 0.09s
Second time loaded 1102 consent entries in 0s
```

Now
```
Loaded 7561 consent envelopes in 5.011s
Loaded 1102 consent entries in 2.264s
Second time loaded 0 consent envelopes in 0.102s
Second time loaded 1102 consent entries in 0s
```