### PR TITLE
Change channel build to https

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -1,10 +1,10 @@
 package org.xmtp.android.library
 
-import io.grpc.Grpc
 import io.grpc.InsecureChannelCredentials
 import io.grpc.ManagedChannel
 import io.grpc.Metadata
 import io.grpc.TlsChannelCredentials
+import io.grpc.okhttp.OkHttpChannelBuilder
 import kotlinx.coroutines.flow.Flow
 import org.xmtp.android.library.messages.Pagination
 import org.xmtp.android.library.messages.Topic
@@ -88,7 +88,7 @@ data class GRPCApiClient(
     }
 
     private val channel: ManagedChannel =
-        Grpc.newChannelBuilderForAddress(
+        OkHttpChannelBuilder.forAddress(
             environment.getValue(),
             if (environment == XMTPEnvironment.LOCAL) 5556 else 443,
             if (secure) {


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-android/issues/223

It seems that the channel builder I was using would sometimes get confused with the prefix of grpc. This should help keep it more inline with https and not accidentally remove the grpc prefix and cause errors.