### PR TITLE
Fix stream timeouts

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.xmtp.android.library.codecs.TextCodec
@@ -146,7 +145,7 @@ class ConversationsTest {
         val bo = PrivateKeyBuilder()
         val alix = PrivateKeyBuilder()
         val clientOptions =
-            ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.DEV, isSecure = true))
+            ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.LOCAL, isSecure = false))
         val boClient = Client().create(bo, clientOptions)
         val alixClient = Client().create(alix, clientOptions)
         val boConversation =

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
@@ -79,7 +79,6 @@ class ConversationsTest {
     }
 
     @Test
-    @Ignore("CI Issues")
     fun testStreamAllMessages() {
         val bo = PrivateKeyBuilder()
         val alix = PrivateKeyBuilder()
@@ -87,7 +86,8 @@ class ConversationsTest {
             ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.LOCAL, isSecure = false))
         val boClient = Client().create(bo, clientOptions)
         val alixClient = Client().create(alix, clientOptions)
-        val boConversation = runBlocking { boClient.conversations.newConversation(alixClient.address) }
+        val boConversation =
+            runBlocking { boClient.conversations.newConversation(alixClient.address) }
 
         // Record message stream across all conversations
         val allMessages = mutableListOf<DecodedMessage>()
@@ -97,7 +97,8 @@ class ConversationsTest {
                 alixClient.conversations.streamAllMessages().collect { message ->
                     allMessages.add(message)
                 }
-            } catch (e: Exception) {}
+            } catch (e: Exception) {
+            }
         }
         sleep(2500)
 
@@ -109,7 +110,8 @@ class ConversationsTest {
 
         val caro = PrivateKeyBuilder()
         val caroClient = Client().create(caro, clientOptions)
-        val caroConversation = runBlocking { caroClient.conversations.newConversation(alixClient.address) }
+        val caroConversation =
+            runBlocking { caroClient.conversations.newConversation(alixClient.address) }
         sleep(2500)
 
         for (i in 0 until 5) {
@@ -137,5 +139,38 @@ class ConversationsTest {
         }
 
         assertEquals(allMessages.size, 15)
+    }
+
+    @Test
+    fun testStreamTimeOutsAllMessages() {
+        val bo = PrivateKeyBuilder()
+        val alix = PrivateKeyBuilder()
+        val clientOptions =
+            ClientOptions(api = ClientOptions.Api(env = XMTPEnvironment.DEV, isSecure = true))
+        val boClient = Client().create(bo, clientOptions)
+        val alixClient = Client().create(alix, clientOptions)
+        val boConversation =
+            runBlocking { boClient.conversations.newConversation(alixClient.address) }
+
+        // Record message stream across all conversations
+        val allMessages = mutableListOf<DecodedMessage>()
+
+        val job = CoroutineScope(Dispatchers.IO).launch {
+            try {
+                alixClient.conversations.streamAllMessages().collect { message ->
+                    allMessages.add(message)
+                }
+            } catch (e: Exception) {
+            }
+        }
+        sleep(2500)
+
+        runBlocking { boConversation.send(text = "first message") }
+        sleep(2000)
+        assertEquals(allMessages.size, 1)
+        sleep(121000)
+        runBlocking { boConversation.send(text = "second message") }
+        sleep(2000)
+        assertEquals(allMessages.size, 2)
     }
 }

--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -95,7 +95,6 @@ data class GRPCApiClient(
                     "backoffMultiplier" to 2.0,
                     "retryableStatusCodes" to listOf(
                         "UNAVAILABLE",
-                        "CANCELLED",
                     )
                 )
             )
@@ -107,7 +106,7 @@ data class GRPCApiClient(
             environment.getValue(),
             if (environment == XMTPEnvironment.LOCAL) 5556 else 443
         ).apply {
-            keepAliveTime(30L, TimeUnit.SECONDS)
+            keepAliveTime(60L, TimeUnit.SECONDS)
             keepAliveTimeout(20L, TimeUnit.SECONDS)
             keepAliveWithoutCalls(true)
             if (environment != XMTPEnvironment.LOCAL) {

--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -106,7 +106,7 @@ data class GRPCApiClient(
             environment.getValue(),
             if (environment == XMTPEnvironment.LOCAL) 5556 else 443
         ).apply {
-            keepAliveTime(60L, TimeUnit.SECONDS)
+            keepAliveTime(3, TimeUnit.MINUTES)
             keepAliveTimeout(20L, TimeUnit.SECONDS)
             keepAliveWithoutCalls(true)
             if (environment != XMTPEnvironment.LOCAL) {


### PR DESCRIPTION
Make sure that streams don't disconnect after 2 minutes, 5 minutes, and 10 minutes. Also confirmed that the poor network tests still work.

Was seeing `io.grpc.okhttp.OkHttpClientTransport$ClientFrameHandler@8913bec: Received GOAWAY with ENHANCE_YOUR_CALM. Debug data: too_many_pings` but no longer with 3 minute for timeout.