### PR TITLE
Remove API timeouts

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/ApiClient.kt
+++ b/library/src/main/java/org/xmtp/android/library/ApiClient.kt
@@ -106,9 +106,6 @@ data class GRPCApiClient(
             environment.getValue(),
             if (environment == XMTPEnvironment.LOCAL) 5556 else 443
         ).apply {
-            keepAliveTime(3, TimeUnit.MINUTES)
-            keepAliveTimeout(20L, TimeUnit.SECONDS)
-            keepAliveWithoutCalls(true)
             if (environment != XMTPEnvironment.LOCAL) {
                 useTransportSecurity()
             } else {


### PR DESCRIPTION
It appears that the timeouts may have been causing the issue. With just the retry logic the API still appears to work for host issues. And by removing the timeouts the default now allows 15 minutes and 30 minutes to go by without dropping the stream.