### PR TITLE
Add ability to disconnect and reconnect database

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -3,7 +3,6 @@ package org.xmtp.android.library
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.fail

--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -13,6 +13,7 @@ import org.xmtp.android.library.messages.PrivateKeyBuilder
 import org.xmtp.android.library.messages.PrivateKeyBundleV1Builder
 import org.xmtp.android.library.messages.generate
 import org.xmtp.proto.message.contents.PrivateKeyOuterClass
+import uniffi.xmtpv3.GenericException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
@@ -205,7 +206,7 @@ class ClientTest {
     fun testDoesNotCreateAV3Client() {
         val fakeWallet = PrivateKeyBuilder()
         val client = Client().create(account = fakeWallet)
-        Assert.assertThrows("Error no V3 client initialized", XMTPException::class.java) {
+        assertThrows("Error no V3 client initialized", XMTPException::class.java) {
             runBlocking {
                 client.canMessageV3(listOf(client.address))[client.address]?.let { assert(!it) }
             }
@@ -286,7 +287,7 @@ class ClientTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val fakeWallet = PrivateKeyBuilder()
         val fakeWallet2 = PrivateKeyBuilder()
-        var boClient =
+        val boClient =
             Client().create(
                 account = fakeWallet,
                 options = ClientOptions(
@@ -316,9 +317,9 @@ class ClientTest {
 
         boClient.dropLocalDatabaseConnection()
 
-        Assert.assertThrows(
-            "Error no V3 client initialized",
-            XMTPException::class.java
+        assertThrows(
+            "Client error: storage error: Pool needs to  reconnect before use",
+            GenericException::class.java
         ) { runBlocking { boClient.conversations.listGroups() } }
 
         runBlocking { boClient.reconnectLocalDatabase() }
@@ -327,5 +328,4 @@ class ClientTest {
             assertEquals(boClient.conversations.listGroups().size, 1)
         }
     }
-
 }

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -613,6 +613,9 @@ class Client() {
         File(dbPath).delete()
     }
 
+    @Deprecated(
+        message = "This function is delicate and should be used with caution. App will error if database not properly reconnected. See: reconnectLocalDatabase()",
+    )
     fun dropLocalDatabaseConnection() {
         libXMTPClient?.releaseDbConnection()
     }

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -613,6 +613,14 @@ class Client() {
         File(dbPath).delete()
     }
 
+    fun dropLocalDatabaseConnection() {
+        libXMTPClient?.releaseDbConnection()
+    }
+
+    suspend fun reconnectLocalDatabase() {
+        libXMTPClient?.dbReconnect() ?: throw XMTPException("Error no V3 client initialized")
+    }
+
     val privateKeyBundle: PrivateKeyBundle
         get() = PrivateKeyBundleBuilder.buildFromV1Key(privateKeyBundleV1)
 


### PR DESCRIPTION
This fixes an IOS bug https://github.com/xmtp/xmtp-ios/issues/336 with app groups but since we are surfacing it in RN I'm adding it to android as well.

Should be used with extreme CAUTION