### PR TITLE
Make all ids strings & add prepare message consent

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -532,10 +532,10 @@ class Client() {
         }
     }
 
-    fun findGroup(groupId: ByteArray): Group? {
+    fun findGroup(groupId: String): Group? {
         v3Client?.let {
             try {
-                return Group(this, it.group(groupId))
+                return Group(this, it.group(groupId.hexToByteArray()))
             } catch (e: Exception) {
                 return null
             }
@@ -543,10 +543,10 @@ class Client() {
         throw XMTPException("Error no V3 client initialized")
     }
 
-    fun findMessage(messageId: ByteArray): MessageV3? {
+    fun findMessage(messageId: String): MessageV3? {
         v3Client?.let {
             try {
-                return MessageV3(this, it.message(messageId))
+                return MessageV3(this, it.message(messageId.hexToByteArray()))
             } catch (e: Exception) {
                 return null
             }

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -249,8 +249,8 @@ class ConsentList(
         return entry?.consentType ?: ConsentState.UNKNOWN
     }
 
-    fun groupState(groupId: ByteArray): ConsentState {
-        val entry = entries[ConsentListEntry.groupId(groupId.toHex()).key]
+    fun groupState(groupId: String): ConsentState {
+        val entry = entries[ConsentListEntry.groupId(groupId).key]
 
         return entry?.consentType ?: ConsentState.UNKNOWN
     }
@@ -288,16 +288,16 @@ data class Contacts(
         consentList.publish(entries)
     }
 
-    suspend fun allowGroups(groupIds: List<ByteArray>) {
+    suspend fun allowGroups(groupIds: List<String>) {
         val entries = groupIds.map {
-            consentList.allowGroup(it.toHex())
+            consentList.allowGroup(it)
         }
         consentList.publish(entries)
     }
 
-    suspend fun denyGroups(groupIds: List<ByteArray>) {
+    suspend fun denyGroups(groupIds: List<String>) {
         val entries = groupIds.map {
-            consentList.denyGroup(it.toHex())
+            consentList.denyGroup(it)
         }
         consentList.publish(entries)
     }
@@ -324,11 +324,11 @@ data class Contacts(
         return consentList.state(address) == ConsentState.DENIED
     }
 
-    fun isGroupAllowed(groupId: ByteArray): Boolean {
+    fun isGroupAllowed(groupId: String): Boolean {
         return consentList.groupState(groupId) == ConsentState.ALLOWED
     }
 
-    fun isGroupDenied(groupId: ByteArray): Boolean {
+    fun isGroupDenied(groupId: String): Boolean {
         return consentList.groupState(groupId) == ConsentState.DENIED
     }
 

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -138,7 +138,7 @@ data class Conversations(
                     groupPinnedFrameUrl = groupPinnedFrameUrl
                 )
             ) ?: throw XMTPException("Client does not support Groups")
-        client.contacts.allowGroups(groupIds = listOf(group.id()))
+        client.contacts.allowGroups(groupIds = listOf(group.id().toHex()))
 
         return Group(client, group)
     }

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -3,7 +3,6 @@ package org.xmtp.android.library
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.runBlocking
 import org.xmtp.android.library.codecs.ContentCodec
 import org.xmtp.android.library.codecs.EncodedContent
 import org.xmtp.android.library.codecs.compress

--- a/library/src/main/java/org/xmtp/android/library/libxmtp/MessageV3.kt
+++ b/library/src/main/java/org/xmtp/android/library/libxmtp/MessageV3.kt
@@ -17,11 +17,11 @@ import java.util.Date
 
 data class MessageV3(val client: Client, private val libXMTPMessage: FfiMessage) {
 
-    val id: ByteArray
-        get() = libXMTPMessage.id
+    val id: String
+        get() = libXMTPMessage.id.toHex()
 
-    val convoId: ByteArray
-        get() = libXMTPMessage.convoId
+    val convoId: String
+        get() = libXMTPMessage.convoId.toHex()
 
     val senderInboxId: String
         get() = libXMTPMessage.senderInboxId
@@ -39,9 +39,9 @@ data class MessageV3(val client: Client, private val libXMTPMessage: FfiMessage)
     fun decode(): DecodedMessage {
         try {
             val decodedMessage = DecodedMessage(
-                id = id.toHex(),
+                id = id,
                 client = client,
-                topic = Topic.groupMessage(convoId.toHex()).description,
+                topic = Topic.groupMessage(convoId).description,
                 encodedContent = EncodedContent.parseFrom(libXMTPMessage.content),
                 senderAddress = senderInboxId,
                 sent = sentAt,
@@ -76,8 +76,8 @@ data class MessageV3(val client: Client, private val libXMTPMessage: FfiMessage)
 
     fun decrypt(): DecryptedMessage {
         return DecryptedMessage(
-            id = id.toHex(),
-            topic = Topic.groupMessage(convoId.toHex()).description,
+            id = id,
+            topic = Topic.groupMessage(convoId).description,
             encodedContent = decode().encodedContent,
             senderAddress = senderInboxId,
             sentAt = sentAt,

--- a/library/src/main/java/org/xmtp/android/library/libxmtp/UnpublishedMessage.kt
+++ b/library/src/main/java/org/xmtp/android/library/libxmtp/UnpublishedMessage.kt
@@ -7,7 +7,8 @@ class UnpublishedMessage(private val libXMTPUnpublishedMessage: FfiUnpublishedMe
     val messageId: String
         get() = libXMTPUnpublishedMessage.id().toHex()
 
-    suspend fun publish() {
+    suspend fun publish(): String {
         libXMTPUnpublishedMessage.publish()
+        return messageId
     }
 }


### PR DESCRIPTION
Lets just make all ids strings for consistency and ease of using the sdk.

Also adds consent for preparing a message.