### PR TITLE
Consent V3

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ContactsTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ContactsTest.kt
@@ -32,13 +32,13 @@ class ContactsTest {
         val fixtures = fixtures()
 
         val contacts = fixtures.bobClient.contacts
-        var result = contacts.isAllowed(fixtures.alice.walletAddress)
+        var result = runBlocking { contacts.isAllowed(fixtures.alice.walletAddress) }
 
         assert(!result)
 
         runBlocking { contacts.allow(listOf(fixtures.alice.walletAddress)) }
 
-        result = contacts.isAllowed(fixtures.alice.walletAddress)
+        result = runBlocking { contacts.isAllowed(fixtures.alice.walletAddress) }
         assert(result)
     }
 
@@ -47,13 +47,13 @@ class ContactsTest {
         val fixtures = fixtures()
 
         val contacts = fixtures.bobClient.contacts
-        var result = contacts.isAllowed(fixtures.alice.walletAddress)
+        var result = runBlocking { contacts.isAllowed(fixtures.alice.walletAddress) }
 
         assert(!result)
 
         runBlocking { contacts.deny(listOf(fixtures.alice.walletAddress)) }
 
-        result = contacts.isDenied(fixtures.alice.walletAddress)
+        result = runBlocking { contacts.isDenied(fixtures.alice.walletAddress) }
         assert(result)
     }
 }

--- a/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
@@ -122,8 +122,13 @@ class GroupTest {
         assert(boGroup.id.isNotEmpty())
         assert(alixGroup.id.isNotEmpty())
 
-        assertEquals(boClient.contacts.consentList.groupState(boGroup.id), ConsentState.ALLOWED)
-        assertEquals(alixClient.contacts.consentList.groupState(alixGroup.id), ConsentState.UNKNOWN)
+        runBlocking {
+            assertEquals(boClient.contacts.consentList.groupState(boGroup.id), ConsentState.ALLOWED)
+            assertEquals(
+                alixClient.contacts.consentList.groupState(alixGroup.id),
+                ConsentState.UNKNOWN
+            )
+        }
 
         runBlocking {
             boGroup.addMembers(listOf(caro.walletAddress))
@@ -424,12 +429,14 @@ class GroupTest {
 
     @Test
     fun testGroupStartsWithAllowedState() {
-        val group = runBlocking { boClient.conversations.newGroup(listOf(alix.walletAddress)) }
-        runBlocking { group.send("howdy") }
-        runBlocking { group.send("gm") }
-        runBlocking { group.sync() }
-        assert(boClient.contacts.isGroupAllowed(group.id))
-        assertEquals(boClient.contacts.consentList.groupState(group.id), ConsentState.ALLOWED)
+        runBlocking {
+            val group = boClient.conversations.newGroup(listOf(alix.walletAddress))
+            group.send("howdy")
+            group.send("gm")
+            group.sync()
+            assert(boClient.contacts.isGroupAllowed(group.id))
+            assertEquals(boClient.contacts.consentList.groupState(group.id), ConsentState.ALLOWED)
+        }
     }
 
     @Test
@@ -772,57 +779,77 @@ class GroupTest {
 
     @Test
     fun testCanAllowGroup() {
-        val group = runBlocking {
-            boClient.conversations.newGroup(
-                listOf(
-                    alix.walletAddress,
-                    caro.walletAddress
+        runBlocking {
+            val group =
+                boClient.conversations.newGroup(
+                    listOf(
+                        alix.walletAddress,
+                        caro.walletAddress
+                    )
                 )
-            )
+
+            var result = boClient.contacts.isGroupAllowed(group.id)
+            assert(result)
+
+            boClient.contacts.allowGroups(listOf(group.id))
+
+            result = boClient.contacts.isGroupAllowed(group.id)
+            assert(result)
         }
-
-        var result = boClient.contacts.isGroupAllowed(group.id)
-        assert(result)
-
-        runBlocking { boClient.contacts.allowGroups(listOf(group.id)) }
-
-        result = boClient.contacts.isGroupAllowed(group.id)
-        assert(result)
     }
 
     @Test
     fun testCanDenyGroup() {
-        val group = runBlocking {
-            boClient.conversations.newGroup(
-                listOf(
-                    alix.walletAddress,
-                    caro.walletAddress
+        runBlocking {
+            val group =
+                boClient.conversations.newGroup(
+                    listOf(
+                        alix.walletAddress,
+                        caro.walletAddress
+                    )
                 )
-            )
+            var result = boClient.contacts.isGroupAllowed(group.id)
+            assert(result)
+
+            boClient.contacts.denyGroups(listOf(group.id))
+
+            result = boClient.contacts.isGroupDenied(group.id)
+            assert(result)
         }
-        var result = boClient.contacts.isGroupAllowed(group.id)
-        assert(result)
-
-        runBlocking { boClient.contacts.denyGroups(listOf(group.id)) }
-
-        result = boClient.contacts.isGroupDenied(group.id)
-        assert(result)
     }
 
     @Test
     fun testCanAllowAndDenyInboxId() {
-        assert(!boClient.contacts.isInboxAllowed(alixClient.inboxId))
-        assert(!boClient.contacts.isInboxDenied(alixClient.inboxId))
+        runBlocking {
+            val boGroup = boClient.conversations.newGroup(listOf(alix.walletAddress))
+            assert(!boClient.contacts.isInboxAllowed(alixClient.inboxId))
+            assert(!boClient.contacts.isInboxDenied(alixClient.inboxId))
 
-        runBlocking { boClient.contacts.allowInboxes(listOf(alixClient.inboxId)) }
+            boClient.contacts.allowInboxes(listOf(alixClient.inboxId))
+            var alixMember = boGroup.members().firstOrNull { it.inboxId == alixClient.inboxId }
+            boGroup.sync()
+            assertEquals(alixMember!!.consentState, ConsentState.ALLOWED)
 
-        assert(boClient.contacts.isInboxAllowed(alixClient.inboxId))
-        assert(!boClient.contacts.isInboxDenied(alixClient.inboxId))
+            assert(boClient.contacts.isInboxAllowed(alixClient.inboxId))
+            assert(!boClient.contacts.isInboxDenied(alixClient.inboxId))
 
-        runBlocking { boClient.contacts.denyInboxes(listOf(alixClient.inboxId)) }
+            boClient.contacts.denyInboxes(listOf(alixClient.inboxId))
+            boGroup.sync()
+            alixMember = boGroup.members().firstOrNull { it.inboxId == alixClient.inboxId }
+            assertEquals(alixMember!!.consentState, ConsentState.DENIED)
 
-        assert(!boClient.contacts.isInboxAllowed(alixClient.inboxId))
-        assert(boClient.contacts.isInboxDenied(alixClient.inboxId))
+            assert(!boClient.contacts.isInboxAllowed(alixClient.inboxId))
+            assert(boClient.contacts.isInboxDenied(alixClient.inboxId))
+
+            boClient.contacts.allow(listOf(alixClient.address))
+            boGroup.sync()
+            alixMember = boGroup.members().firstOrNull { it.inboxId == alixClient.inboxId }
+            assertEquals(alixMember!!.consentState, ConsentState.ALLOWED)
+            assert(boClient.contacts.isInboxAllowed(alixClient.inboxId))
+            assert(!boClient.contacts.isInboxDenied(alixClient.inboxId))
+            assert(boClient.contacts.isAllowed(alixClient.address))
+            assert(!boClient.contacts.isDenied(alixClient.address))
+        }
     }
 
     @Test
@@ -872,9 +899,9 @@ class GroupTest {
         }
         runBlocking { alixClient.conversations.syncGroups() }
         val alixGroup: Group = alixClient.findGroup(boGroup.id)!!
-        assert(!alixClient.contacts.isGroupAllowed(boGroup.id))
+        runBlocking { assert(!alixClient.contacts.isGroupAllowed(boGroup.id)) }
         val preparedMessageId = runBlocking { alixGroup.prepareMessage("Test text") }
-        assert(alixClient.contacts.isGroupAllowed(boGroup.id))
+        runBlocking { assert(alixClient.contacts.isGroupAllowed(boGroup.id)) }
         assertEquals(alixGroup.messages().size, 1)
         assertEquals(alixGroup.messages(deliveryStatus = MessageDeliveryStatus.PUBLISHED).size, 0)
         assertEquals(alixGroup.messages(deliveryStatus = MessageDeliveryStatus.UNPUBLISHED).size, 1)

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -90,10 +90,9 @@ class Client() {
     var logger: XMTPLogger = XMTPLogger()
     val libXMTPVersion: String = getVersionInfo()
     var installationId: String = ""
-    private var v3Client: FfiXmtpClient? = null
+    var v3Client: FfiXmtpClient? = null
     var dbPath: String = ""
     lateinit var inboxId: String
-    var hasV3Client: Boolean = false
     var hasV2Client: Boolean = false
 
     companion object {
@@ -359,7 +358,6 @@ class Client() {
             }
 
         if (v3Client != null) {
-            hasV3Client = true
             options.preAuthenticateToInboxCallback?.let {
                 runBlocking {
                     it.invoke()

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -93,7 +93,7 @@ class Client() {
     var v3Client: FfiXmtpClient? = null
     var dbPath: String = ""
     lateinit var inboxId: String
-    var hasV2Client: Boolean = false
+    var hasV2Client: Boolean = true
 
     companion object {
         private const val TAG = "Client"
@@ -278,7 +278,6 @@ class Client() {
         options: ClientOptions? = null,
         account: SigningKey? = null,
     ): Client {
-        hasV2Client = true
         val address = v1Bundle.identityKey.publicKey.recoverWalletSignerPublicKey().walletAddress
         val newOptions = options ?: ClientOptions()
         val v2Client =
@@ -397,7 +396,6 @@ class Client() {
         apiClient: ApiClient,
         options: ClientOptions? = null,
     ): PrivateKeyBundleV1 {
-        hasV2Client = true
         val keys = loadPrivateKeys(account, apiClient, options)
         return if (keys != null) {
             keys

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -93,6 +93,8 @@ class Client() {
     private var v3Client: FfiXmtpClient? = null
     var dbPath: String = ""
     lateinit var inboxId: String
+    var hasV3Client: Boolean = false
+    var hasV2Client: Boolean = false
 
     companion object {
         private const val TAG = "Client"
@@ -277,6 +279,7 @@ class Client() {
         options: ClientOptions? = null,
         account: SigningKey? = null,
     ): Client {
+        hasV2Client = true
         val address = v1Bundle.identityKey.publicKey.recoverWalletSignerPublicKey().walletAddress
         val newOptions = options ?: ClientOptions()
         val v2Client =
@@ -356,6 +359,7 @@ class Client() {
             }
 
         if (v3Client != null) {
+            hasV3Client = true
             options.preAuthenticateToInboxCallback?.let {
                 runBlocking {
                     it.invoke()
@@ -395,6 +399,7 @@ class Client() {
         apiClient: ApiClient,
         options: ClientOptions? = null,
     ): PrivateKeyBundleV1 {
+        hasV2Client = true
         val keys = loadPrivateKeys(account, apiClient, options)
         return if (keys != null) {
             keys

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -11,7 +11,6 @@ import org.xmtp.proto.message.api.v1.MessageApiOuterClass
 import org.xmtp.proto.message.contents.PrivatePreferences.PrivatePreferencesAction
 import uniffi.xmtpv3.FfiConsentEntityType
 import uniffi.xmtpv3.FfiConsentState
-import uniffi.xmtpv3.FfiGroupPermissionsOptions
 import java.util.Date
 
 enum class ConsentState {
@@ -61,7 +60,6 @@ enum class EntryType {
         }
     }
 }
-
 
 data class ConsentListEntry(
     val value: String,

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -222,7 +222,7 @@ class ConsentList(
     }
 
     suspend fun setV3ConsentState(entries: List<ConsentListEntry>) {
-        entries.forEach {
+        entries.iterator().forEach {
             client.v3Client?.setConsentState(
                 ConsentState.toFfiConsentState(it.consentType),
                 EntryType.toFfiConsentEntityType(it.entryType),

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -9,12 +9,32 @@ import org.xmtp.android.library.messages.Topic
 import org.xmtp.android.library.messages.walletAddress
 import org.xmtp.proto.message.api.v1.MessageApiOuterClass
 import org.xmtp.proto.message.contents.PrivatePreferences.PrivatePreferencesAction
+import uniffi.xmtpv3.FfiConsentState
+import uniffi.xmtpv3.FfiGroupPermissionsOptions
 import java.util.Date
 
 enum class ConsentState {
     ALLOWED,
     DENIED,
-    UNKNOWN,
+    UNKNOWN;
+
+    companion object {
+        fun toFfiConsentState(option: ConsentState): FfiConsentState {
+            return when (option) {
+                ConsentState.ALLOWED -> FfiConsentState.ALLOWED
+                ConsentState.DENIED -> FfiConsentState.DENIED
+                else -> FfiConsentState.UNKNOWN
+            }
+        }
+
+        fun fromFfiConsentState(option: FfiConsentState): ConsentState {
+            return when (option) {
+                FfiConsentState.ALLOWED -> ConsentState.ALLOWED
+                FfiConsentState.DENIED -> ConsentState.DENIED
+                else -> ConsentState.UNKNOWN
+            }
+        }
+    }
 }
 
 data class ConsentListEntry(

--- a/library/src/main/java/org/xmtp/android/library/Contacts.kt
+++ b/library/src/main/java/org/xmtp/android/library/Contacts.kt
@@ -169,60 +169,37 @@ class ConsentList(
         if (client.hasV2Client) {
             val payload = PrivatePreferencesAction.newBuilder().also {
                 entries.iterator().forEach { entry ->
-                    when (entry.entryType) {
-                        EntryType.ADDRESS -> {
-                            when (entry.consentType) {
-                                ConsentState.ALLOWED ->
-                                    it.setAllowAddress(
-                                        PrivatePreferencesAction.AllowAddress.newBuilder()
-                                            .addWalletAddresses(entry.value),
-                                    )
+                    when (entry.entryType to entry.consentType) {
+                        EntryType.ADDRESS to ConsentState.ALLOWED -> it.setAllowAddress(
+                            PrivatePreferencesAction.AllowAddress.newBuilder()
+                                .addWalletAddresses(entry.value)
+                        )
 
-                                ConsentState.DENIED ->
-                                    it.setDenyAddress(
-                                        PrivatePreferencesAction.DenyAddress.newBuilder()
-                                            .addWalletAddresses(entry.value),
-                                    )
+                        EntryType.ADDRESS to ConsentState.DENIED -> it.setDenyAddress(
+                            PrivatePreferencesAction.DenyAddress.newBuilder()
+                                .addWalletAddresses(entry.value)
+                        )
 
-                                ConsentState.UNKNOWN -> it.clearMessageType()
-                            }
-                        }
+                        EntryType.GROUP_ID to ConsentState.ALLOWED -> it.setAllowGroup(
+                            PrivatePreferencesAction.AllowGroup.newBuilder()
+                                .addGroupIds(entry.value)
+                        )
 
-                        EntryType.GROUP_ID -> {
-                            when (entry.consentType) {
-                                ConsentState.ALLOWED ->
-                                    it.setAllowGroup(
-                                        PrivatePreferencesAction.AllowGroup.newBuilder()
-                                            .addGroupIds(entry.value),
-                                    )
+                        EntryType.GROUP_ID to ConsentState.DENIED -> it.setDenyGroup(
+                            PrivatePreferencesAction.DenyGroup.newBuilder().addGroupIds(entry.value)
+                        )
 
-                                ConsentState.DENIED ->
-                                    it.setDenyGroup(
-                                        PrivatePreferencesAction.DenyGroup.newBuilder()
-                                            .addGroupIds(entry.value),
-                                    )
+                        EntryType.INBOX_ID to ConsentState.ALLOWED -> it.setAllowInboxId(
+                            PrivatePreferencesAction.AllowInboxId.newBuilder()
+                                .addInboxIds(entry.value)
+                        )
 
-                                ConsentState.UNKNOWN -> it.clearMessageType()
-                            }
-                        }
+                        EntryType.INBOX_ID to ConsentState.DENIED -> it.setDenyInboxId(
+                            PrivatePreferencesAction.DenyInboxId.newBuilder()
+                                .addInboxIds(entry.value)
+                        )
 
-                        EntryType.INBOX_ID -> {
-                            when (entry.consentType) {
-                                ConsentState.ALLOWED ->
-                                    it.setAllowInboxId(
-                                        PrivatePreferencesAction.AllowInboxId.newBuilder()
-                                            .addInboxIds(entry.value),
-                                    )
-
-                                ConsentState.DENIED ->
-                                    it.setDenyInboxId(
-                                        PrivatePreferencesAction.DenyInboxId.newBuilder()
-                                            .addInboxIds(entry.value),
-                                    )
-
-                                ConsentState.UNKNOWN -> it.clearMessageType()
-                            }
-                        }
+                        else -> it.clearMessageType()
                     }
                 }
             }.build()

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -93,7 +93,7 @@ sealed class Conversation {
         return when (this) {
             is V1 -> conversationV1.client.contacts.consentList.state(address = peerAddress)
             is V2 -> conversationV2.client.contacts.consentList.state(address = peerAddress)
-            is Group -> group.client.contacts.consentList.groupState(groupId = group.id)
+            is Group -> group.consentState()
         }
     }
 

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -89,7 +89,7 @@ sealed class Conversation {
             }
         }
 
-    fun consentState(): ConsentState {
+    suspend fun consentState(): ConsentState {
         return when (this) {
             is V1 -> conversationV1.client.contacts.consentList.state(address = peerAddress)
             is V2 -> conversationV2.client.contacts.consentList.state(address = peerAddress)

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -66,8 +66,8 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
     }
 
     suspend fun send(encodedContent: EncodedContent): String {
-        if (consentState() == ConsentState.UNKNOWN) {
-            updateConsentState(ConsentState.ALLOWED)
+        if (client.contacts.consentList.groupState(groupId = id) == ConsentState.UNKNOWN) {
+            client.contacts.allowGroups(groupIds = listOf(id))
         }
         val messageId = libXMTPGroup.send(contentBytes = encodedContent.toByteArray())
         return messageId.toHex()
@@ -100,8 +100,8 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
     }
 
     suspend fun <T> prepareMessage(content: T, options: SendOptions? = null): String {
-        if (consentState() == ConsentState.UNKNOWN) {
-            updateConsentState(ConsentState.ALLOWED)
+        if (client.contacts.consentList.groupState(groupId = id) == ConsentState.UNKNOWN) {
+            client.contacts.allowGroups(groupIds = listOf(id))
         }
         val encodeContent = encodeContent(content = content, options = options)
         return libXMTPGroup.sendOptimistic(encodeContent.toByteArray()).toHex()

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -66,8 +66,8 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
     }
 
     suspend fun send(encodedContent: EncodedContent): String {
-        if (client.contacts.consentList.groupState(groupId = id) == ConsentState.UNKNOWN) {
-            client.contacts.allowGroups(groupIds = listOf(id))
+        if (consentState() == ConsentState.UNKNOWN) {
+            updateConsentState(ConsentState.ALLOWED)
         }
         val messageId = libXMTPGroup.send(contentBytes = encodedContent.toByteArray())
         return messageId.toHex()
@@ -100,8 +100,8 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
     }
 
     suspend fun <T> prepareMessage(content: T, options: SendOptions? = null): String {
-        if (client.contacts.consentList.groupState(groupId = id) == ConsentState.UNKNOWN) {
-            client.contacts.allowGroups(groupIds = listOf(id))
+        if (consentState() == ConsentState.UNKNOWN) {
+            updateConsentState(ConsentState.ALLOWED)
         }
         val encodeContent = encodeContent(content = content, options = options)
         return libXMTPGroup.sendOptimistic(encodeContent.toByteArray()).toHex()

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -178,7 +178,15 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
         return MessageV3(client, message)
     }
 
-    fun updateConsentState(state: ConsentState) {
+    suspend fun updateConsentState(state: ConsentState) {
+        if (client.hasV2Client) {
+            when (state) {
+                ConsentState.ALLOWED -> client.contacts.allowGroups(groupIds = listOf(id))
+                ConsentState.DENIED -> client.contacts.denyGroups(groupIds = listOf(id))
+                ConsentState.UNKNOWN -> Unit
+            }
+        }
+
         val consentState = ConsentState.toFfiConsentState(state)
         libXMTPGroup.updateConsentState(consentState)
     }

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -178,6 +178,15 @@ class Group(val client: Client, private val libXMTPGroup: FfiGroup) {
         return MessageV3(client, message)
     }
 
+    fun updateConsentState(state: ConsentState) {
+        val consentState = ConsentState.toFfiConsentState(state)
+        libXMTPGroup.updateConsentState(consentState)
+    }
+
+    fun consentState(): ConsentState {
+        return ConsentState.fromFfiConsentState(libXMTPGroup.consentState())
+    }
+
     fun isActive(): Boolean {
         return libXMTPGroup.isActive()
     }

--- a/library/src/main/java/org/xmtp/android/library/libxmtp/Member.kt
+++ b/library/src/main/java/org/xmtp/android/library/libxmtp/Member.kt
@@ -1,5 +1,6 @@
 package org.xmtp.android.library.libxmtp
 
+import org.xmtp.android.library.ConsentState
 import uniffi.xmtpv3.FfiGroupMember
 import uniffi.xmtpv3.FfiPermissionLevel
 
@@ -18,4 +19,7 @@ class Member(private val ffiMember: FfiGroupMember) {
             FfiPermissionLevel.ADMIN -> PermissionLevel.ADMIN
             FfiPermissionLevel.SUPER_ADMIN -> PermissionLevel.SUPER_ADMIN
         }
+
+    val consentState: ConsentState
+        get() = ConsentState.fromFfiConsentState(ffiMember.consentState)
 }


### PR DESCRIPTION
Part of https://github.com/xmtp/libxmtp/issues/801

This adds the ability to get and set consent records in V3

Dual sends so we are always setting both V2 and V3 consent. And adds a check to see if a V2Client is present to support pure V3 clients.