### PR TITLE
Fix pagination not being respected in group messages

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -45,6 +45,8 @@ import org.xmtp.proto.message.contents.Invitation
 import org.xmtp.proto.message.contents.Invitation.InvitationV1.Context
 import java.nio.charset.StandardCharsets
 import java.util.Date
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.DurationUnit
 
 @RunWith(AndroidJUnit4::class)
 class ConversationTest {
@@ -418,7 +420,11 @@ class ConversationTest {
             val messages = aliceConversation.messages(limit = 1)
             assertEquals(1, messages.size)
             assertEquals("hey alice 3", messages[0].body)
-            val messages2 = aliceConversation.messages(limit = 1, after = date)
+            val messages2 = aliceConversation.messages(
+                limit = 1, afterNs = date.time.nanoseconds.toLong(
+                    DurationUnit.NANOSECONDS
+                )
+            )
             assertEquals(1, messages2.size)
             assertEquals("hey alice 3", messages2[0].body)
             val messagesAsc =

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationTest.kt
@@ -421,7 +421,8 @@ class ConversationTest {
             assertEquals(1, messages.size)
             assertEquals("hey alice 3", messages[0].body)
             val messages2 = aliceConversation.messages(
-                limit = 1, afterNs = date.time.nanoseconds.toLong(
+                limit = 1,
+                afterNs = date.time.nanoseconds.toLong(
                     DurationUnit.NANOSECONDS
                 )
             )

--- a/library/src/androidTest/java/org/xmtp/android/library/LocalInstrumentedTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/LocalInstrumentedTest.kt
@@ -29,6 +29,8 @@ import org.xmtp.proto.message.contents.PrivateKeyOuterClass
 import org.xmtp.proto.message.contents.PrivateKeyOuterClass.PrivateKeyBundle
 import uniffi.xmtpv3.createV2Client
 import java.util.Date
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.DurationUnit
 
 @RunWith(AndroidJUnit4::class)
 class LocalInstrumentedTest {
@@ -163,10 +165,18 @@ class LocalInstrumentedTest {
             assertEquals(2, messagesLimit.size)
             val nowMessage = messages[0]
             assertEquals("now", nowMessage.body)
-            val messages2 = convo.messages(limit = 1, before = nowMessage.sent)
+            val messages2 = convo.messages(
+                limit = 1, beforeNs = nowMessage.sent.time.nanoseconds.toLong(
+                    DurationUnit.NANOSECONDS
+                )
+            )
             val tenSecondsAgoMessage = messages2[0]
             assertEquals("now first", tenSecondsAgoMessage.body)
-            val messages3 = convo.messages(after = tenSecondsAgoMessage.sent)
+            val messages3 = convo.messages(
+                afterNs = tenSecondsAgoMessage.sent.time.nanoseconds.toLong(
+                    DurationUnit.NANOSECONDS
+                )
+            )
             val nowMessage2 = messages3[0]
             assertEquals("now", nowMessage2.body)
             val messagesAsc =

--- a/library/src/androidTest/java/org/xmtp/android/library/LocalInstrumentedTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/LocalInstrumentedTest.kt
@@ -166,7 +166,8 @@ class LocalInstrumentedTest {
             val nowMessage = messages[0]
             assertEquals("now", nowMessage.body)
             val messages2 = convo.messages(
-                limit = 1, beforeNs = nowMessage.sent.time.nanoseconds.toLong(
+                limit = 1,
+                beforeNs = nowMessage.sent.time.nanoseconds.toLong(
                     DurationUnit.NANOSECONDS
                 )
             )

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -169,50 +169,71 @@ sealed class Conversation {
      */
     suspend fun messages(
         limit: Int? = null,
-        before: Date? = null,
-        after: Date? = null,
+        beforeNs: Long? = null,
+        afterNs: Long? = null,
         direction: PagingInfoSortDirection = MessageApiOuterClass.SortDirection.SORT_DIRECTION_DESCENDING,
     ): List<DecodedMessage> {
         return when (this) {
             is V1 -> conversationV1.messages(
                 limit = limit,
-                before = before,
-                after = after,
+                before = beforeNs?.let { Date(it / 1_000_000) },
+                after = afterNs?.let { Date(it / 1_000_000) },
                 direction = direction,
             )
 
             is V2 ->
                 conversationV2.messages(
                     limit = limit,
-                    before = before,
-                    after = after,
+                    before = beforeNs?.let { Date(it / 1_000_000) },
+                    after = afterNs?.let { Date(it / 1_000_000) },
                     direction = direction,
                 )
 
             is Group -> {
                 group.messages(
                     limit = limit,
-                    before = before,
-                    after = after,
+                    beforeNs = beforeNs,
+                    afterNs = afterNs,
                     direction = direction,
                 )
             }
 
-            is Dm -> dm.messages(limit, before, after, direction)
+            is Dm -> dm.messages(limit, beforeNs, afterNs, direction)
         }
     }
 
     suspend fun decryptedMessages(
         limit: Int? = null,
-        before: Date? = null,
-        after: Date? = null,
+        beforeNs: Long? = null,
+        afterNs: Long? = null,
         direction: PagingInfoSortDirection = MessageApiOuterClass.SortDirection.SORT_DIRECTION_DESCENDING,
     ): List<DecryptedMessage> {
         return when (this) {
-            is V1 -> conversationV1.decryptedMessages(limit, before, after, direction)
-            is V2 -> conversationV2.decryptedMessages(limit, before, after, direction)
-            is Group -> group.decryptedMessages(limit, before, after, direction)
-            is Dm -> dm.decryptedMessages(limit, before, after, direction)
+            is V1 -> conversationV1.decryptedMessages(
+                limit = limit,
+                before = beforeNs?.let { Date(it / 1_000_000) },
+                after = afterNs?.let { Date(it / 1_000_000) },
+                direction = direction,
+            )
+
+            is V2 ->
+                conversationV2.decryptedMessages(
+                    limit = limit,
+                    before = beforeNs?.let { Date(it / 1_000_000) },
+                    after = afterNs?.let { Date(it / 1_000_000) },
+                    direction = direction,
+                )
+
+            is Group -> {
+                group.decryptedMessages(
+                    limit = limit,
+                    beforeNs = beforeNs,
+                    afterNs = afterNs,
+                    direction = direction,
+                )
+            }
+
+            is Dm -> dm.decryptedMessages(limit, beforeNs, afterNs, direction)
         }
     }
 

--- a/library/src/main/java/org/xmtp/android/library/Dm.kt
+++ b/library/src/main/java/org/xmtp/android/library/Dm.kt
@@ -23,8 +23,6 @@ import uniffi.xmtpv3.FfiMessage
 import uniffi.xmtpv3.FfiMessageCallback
 import uniffi.xmtpv3.FfiSubscribeException
 import java.util.Date
-import kotlin.time.Duration.Companion.nanoseconds
-import kotlin.time.DurationUnit
 
 class Dm(val client: Client, private val libXMTPGroup: FfiConversation) {
     val id: String
@@ -103,15 +101,15 @@ class Dm(val client: Client, private val libXMTPGroup: FfiConversation) {
 
     fun messages(
         limit: Int? = null,
-        before: Date? = null,
-        after: Date? = null,
+        beforeNs: Long? = null,
+        afterNs: Long? = null,
         direction: PagingInfoSortDirection = SortDirection.SORT_DIRECTION_DESCENDING,
         deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.ALL,
     ): List<DecodedMessage> {
         return libXMTPGroup.findMessages(
             opts = FfiListMessagesOptions(
-                sentBeforeNs = before?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
-                sentAfterNs = after?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
+                sentBeforeNs = beforeNs,
+                sentAfterNs = afterNs,
                 limit = limit?.toLong(),
                 deliveryStatus = when (deliveryStatus) {
                     MessageDeliveryStatus.PUBLISHED -> FfiDeliveryStatus.PUBLISHED
@@ -131,15 +129,15 @@ class Dm(val client: Client, private val libXMTPGroup: FfiConversation) {
 
     fun decryptedMessages(
         limit: Int? = null,
-        before: Date? = null,
-        after: Date? = null,
+        beforeNs: Long? = null,
+        afterNs: Long? = null,
         direction: PagingInfoSortDirection = SortDirection.SORT_DIRECTION_DESCENDING,
         deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.ALL,
     ): List<DecryptedMessage> {
         return libXMTPGroup.findMessages(
             opts = FfiListMessagesOptions(
-                sentBeforeNs = before?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
-                sentAfterNs = after?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
+                sentBeforeNs = beforeNs,
+                sentAfterNs = afterNs,
                 limit = limit?.toLong(),
                 deliveryStatus = when (deliveryStatus) {
                     MessageDeliveryStatus.PUBLISHED -> FfiDeliveryStatus.PUBLISHED

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -29,8 +29,6 @@ import uniffi.xmtpv3.FfiSubscribeException
 import uniffi.xmtpv3.org.xmtp.android.library.libxmtp.PermissionOption
 import uniffi.xmtpv3.org.xmtp.android.library.libxmtp.PermissionPolicySet
 import java.util.Date
-import kotlin.time.Duration.Companion.nanoseconds
-import kotlin.time.DurationUnit
 
 class Group(val client: Client, private val libXMTPGroup: FfiConversation) {
     val id: String
@@ -121,15 +119,15 @@ class Group(val client: Client, private val libXMTPGroup: FfiConversation) {
 
     fun messages(
         limit: Int? = null,
-        before: Date? = null,
-        after: Date? = null,
+        beforeNs: Long? = null,
+        afterNs: Long? = null,
         direction: PagingInfoSortDirection = SORT_DIRECTION_DESCENDING,
         deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.ALL,
     ): List<DecodedMessage> {
         return libXMTPGroup.findMessages(
             opts = FfiListMessagesOptions(
-                sentBeforeNs = before?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
-                sentAfterNs = after?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
+                sentBeforeNs = beforeNs,
+                sentAfterNs = afterNs,
                 limit = limit?.toLong(),
                 deliveryStatus = when (deliveryStatus) {
                     MessageDeliveryStatus.PUBLISHED -> FfiDeliveryStatus.PUBLISHED
@@ -149,15 +147,15 @@ class Group(val client: Client, private val libXMTPGroup: FfiConversation) {
 
     fun decryptedMessages(
         limit: Int? = null,
-        before: Date? = null,
-        after: Date? = null,
+        beforeNs: Long? = null,
+        afterNs: Long? = null,
         direction: PagingInfoSortDirection = SORT_DIRECTION_DESCENDING,
         deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.ALL,
     ): List<DecryptedMessage> {
         return libXMTPGroup.findMessages(
             opts = FfiListMessagesOptions(
-                sentBeforeNs = before?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
-                sentAfterNs = after?.time?.nanoseconds?.toLong(DurationUnit.NANOSECONDS),
+                sentBeforeNs = beforeNs,
+                sentAfterNs = afterNs,
                 limit = limit?.toLong(),
                 deliveryStatus = when (deliveryStatus) {
                     MessageDeliveryStatus.PUBLISHED -> FfiDeliveryStatus.PUBLISHED

--- a/library/src/main/java/org/xmtp/android/library/libxmtp/MessageV3.kt
+++ b/library/src/main/java/org/xmtp/android/library/libxmtp/MessageV3.kt
@@ -29,6 +29,9 @@ data class MessageV3(val client: Client, private val libXMTPMessage: FfiMessage)
     val sentAt: Date
         get() = Date(libXMTPMessage.sentAtNs / 1_000_000)
 
+    val sentAtNs: Long
+        get() = libXMTPMessage.sentAtNs
+
     val deliveryStatus: MessageDeliveryStatus
         get() = when (libXMTPMessage.deliveryStatus) {
             FfiDeliveryStatus.UNPUBLISHED -> MessageDeliveryStatus.UNPUBLISHED


### PR DESCRIPTION
Fixes: https://github.com/xmtp/xmtp-android/issues/311

Reproduce the after and before not being respected in the messages field.