### PR TITLE
List of inbox states for inbox ids

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.xmtp.android.library.messages.PrivateKeyBuilder
+import org.xmtp.android.library.messages.walletAddress
 import uniffi.xmtpv3.GenericException
 import java.security.SecureRandom
 import java.util.concurrent.CompletableFuture
@@ -319,5 +320,18 @@ class ClientTest {
 
         state = runBlocking { alixClient3.inboxState(true) }
         assertEquals(state.installations.size, 1)
+    }
+
+    @Test
+    fun testsCanFindOthersInboxStates() {
+        val fixtures = fixtures()
+        val states = runBlocking {
+            fixtures.alixClient.inboxStatesForInboxIds(
+                true,
+                listOf(fixtures.boClient.inboxId, fixtures.caroClient.inboxId)
+            )
+        }
+        assertEquals(states.first().recoveryAddress.lowercase(), fixtures.bo.walletAddress.lowercase())
+        assertEquals(states.last().recoveryAddress.lowercase(), fixtures.caro.walletAddress.lowercase())
     }
 }

--- a/library/src/androidTest/java/org/xmtp/android/library/DmTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/DmTest.kt
@@ -65,8 +65,8 @@ class DmTest {
         runBlocking {
             val dm = boClient.conversations.findOrCreateDm(caro.walletAddress)
 
-            val caroDm = boClient.findDm(caro.walletAddress)
-            val alixDm = boClient.findDm(alix.walletAddress)
+            val caroDm = boClient.findDmFromAddress(caro.walletAddress)
+            val alixDm = boClient.findDmFromAddress(alix.walletAddress)
             assertNull(alixDm)
             assertEquals(caroDm?.id, dm.id)
         }
@@ -253,7 +253,7 @@ class DmTest {
     fun testCanStreamDmMessages() = kotlinx.coroutines.test.runTest {
         val group = boClient.conversations.findOrCreateDm(alix.walletAddress.lowercase())
         alixClient.conversations.sync()
-        val alixDm = alixClient.findDm(bo.walletAddress)
+        val alixDm = alixClient.findDmFromAddress(bo.walletAddress)
         group.streamMessages().test {
             alixDm?.send("hi")
             assertEquals("hi", awaitItem().body)

--- a/library/src/androidTest/java/org/xmtp/android/library/DmTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/DmTest.kt
@@ -61,12 +61,24 @@ class DmTest {
     }
 
     @Test
+    fun testsCanFindDmByInboxId() {
+        runBlocking {
+            val dm = boClient.conversations.findOrCreateDm(caro.walletAddress)
+
+            val caroDm = boClient.findDmByInboxId(caroClient.inboxId)
+            val alixDm = boClient.findDmByInboxId(alixClient.inboxId)
+            assertNull(alixDm)
+            assertEquals(caroDm?.id, dm.id)
+        }
+    }
+
+    @Test
     fun testsCanFindDmByAddress() {
         runBlocking {
             val dm = boClient.conversations.findOrCreateDm(caro.walletAddress)
 
-            val caroDm = boClient.findDmFromAddress(caro.walletAddress)
-            val alixDm = boClient.findDmFromAddress(alix.walletAddress)
+            val caroDm = boClient.findDmByAddress(caro.walletAddress)
+            val alixDm = boClient.findDmByAddress(alix.walletAddress)
             assertNull(alixDm)
             assertEquals(caroDm?.id, dm.id)
         }
@@ -253,7 +265,7 @@ class DmTest {
     fun testCanStreamDmMessages() = kotlinx.coroutines.test.runTest {
         val group = boClient.conversations.findOrCreateDm(alix.walletAddress.lowercase())
         alixClient.conversations.sync()
-        val alixDm = alixClient.findDmFromAddress(bo.walletAddress)
+        val alixDm = alixClient.findDmByAddress(bo.walletAddress)
         group.streamMessages().test {
             alixDm?.send("hi")
             assertEquals("hi", awaitItem().body)

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -248,14 +248,18 @@ class Client() {
         }
     }
 
-    suspend fun findDm(address: String): Dm? {
-        val inboxId =
-            inboxIdFromAddress(address.lowercase()) ?: throw XMTPException("No inboxId present")
+    fun findDmFromInboxId(inboxId: String): Dm? {
         return try {
             Dm(this, ffiClient.dmConversation(inboxId))
         } catch (e: Exception) {
             null
         }
+    }
+
+    suspend fun findDmFromAddress(address: String): Dm? {
+        val inboxId =
+            inboxIdFromAddress(address.lowercase()) ?: throw XMTPException("No inboxId present")
+        return findDmFromInboxId(inboxId)
     }
 
     fun findMessage(messageId: String): Message? {
@@ -304,6 +308,13 @@ class Client() {
             signatureRequest.addEcdsaSignature(it.rawData)
             ffiClient.applySignatureRequest(signatureRequest)
         }
+    }
+
+    suspend fun inboxStatesForInboxIds(
+        refreshFromNetwork: Boolean,
+        inboxIds: List<String>,
+    ): List<InboxState> {
+        return ffiClient.addressesFromInboxId(refreshFromNetwork, inboxIds).map { InboxState(it) }
     }
 
     suspend fun inboxState(refreshFromNetwork: Boolean): InboxState {

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -248,7 +248,7 @@ class Client() {
         }
     }
 
-    fun findDmFromInboxId(inboxId: String): Dm? {
+    fun findDmByInboxId(inboxId: String): Dm? {
         return try {
             Dm(this, ffiClient.dmConversation(inboxId))
         } catch (e: Exception) {
@@ -256,10 +256,10 @@ class Client() {
         }
     }
 
-    suspend fun findDmFromAddress(address: String): Dm? {
+    suspend fun findDmByAddress(address: String): Dm? {
         val inboxId =
             inboxIdFromAddress(address.lowercase()) ?: throw XMTPException("No inboxId present")
-        return findDmFromInboxId(inboxId)
+        return findDmByInboxId(inboxId)
     }
 
     fun findMessage(messageId: String): Message? {

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -146,7 +146,7 @@ data class Conversations(
         if (falseAddresses.isNotEmpty()) {
             throw XMTPException("${falseAddresses.joinToString()} not on network")
         }
-        var dm = client.findDmFromAddress(peerAddress)
+        var dm = client.findDmByAddress(peerAddress)
         if (dm == null) {
             val dmConversation = ffiConversations.createDm(peerAddress.lowercase())
             dm = Dm(client, dmConversation)

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -146,7 +146,7 @@ data class Conversations(
         if (falseAddresses.isNotEmpty()) {
             throw XMTPException("${falseAddresses.joinToString()} not on network")
         }
-        var dm = client.findDm(peerAddress)
+        var dm = client.findDmFromAddress(peerAddress)
         if (dm == null) {
             val dmConversation = ffiConversations.createDm(peerAddress.lowercase())
             dm = Dm(client, dmConversation)


### PR DESCRIPTION
Exposes the inbox state for inbox ids so that you can map addresses to a list of inbox ids. 

Also adds a function to `findDmByInboxId` to make it easier for clients not storing addreses.