### PR TITLE
Send encoded content added to Conversation class

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -1,6 +1,7 @@
 package org.xmtp.android.library
 
 import kotlinx.coroutines.flow.Flow
+import org.xmtp.android.library.codecs.EncodedContent
 import org.xmtp.android.library.libxmtp.Member
 import org.xmtp.android.library.libxmtp.Message
 import java.util.Date
@@ -75,6 +76,13 @@ sealed class Conversation {
         return when (this) {
             is Group -> group.send(content = content, options = options)
             is Dm -> dm.send(content = content, options = options)
+        }
+    }
+
+    suspend fun send(encodedContent: EncodedContent): String {
+        return when (this) {
+            is Group -> group.send(encodedContent)
+            is Dm -> dm.send(encodedContent)
         }
     }
 


### PR DESCRIPTION
This change unblocks custom content types in V3. 

Related to https://github.com/xmtp/xmtp-react-native/pull/559