### PR TITLE
Remove client from serializable objects

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -86,7 +86,6 @@ class ClientTest {
                     notOnNetwork.address,
                     fixtures.bo.walletAddress
                 ),
-                context,
                 ClientOptions.Api(XMTPEnvironment.LOCAL, false)
             )
         }
@@ -109,7 +108,6 @@ class ClientTest {
         val states = runBlocking {
             Client.inboxStatesForInboxIds(
                 listOf(fixtures.boClient.inboxId, fixtures.caroClient.inboxId),
-                context,
                 ClientOptions.Api(XMTPEnvironment.LOCAL, false)
             )
         }

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -304,7 +304,7 @@ class Client() {
 
     fun findGroup(groupId: String): Group? {
         return try {
-            Group(this, ffiClient.conversation(groupId.hexToByteArray()))
+            Group(this.inboxId, ffiClient.conversation(groupId.hexToByteArray()))
         } catch (e: Exception) {
             null
         }
@@ -314,8 +314,8 @@ class Client() {
         return try {
             val conversation = ffiClient.conversation(conversationId.hexToByteArray())
             when (conversation.conversationType()) {
-                FfiConversationType.GROUP -> Conversation.Group(Group(this, conversation))
-                FfiConversationType.DM -> Conversation.Dm(Dm(this, conversation))
+                FfiConversationType.GROUP -> Conversation.Group(Group(this.inboxId, conversation))
+                FfiConversationType.DM -> Conversation.Dm(Dm(this.inboxId, conversation))
                 else -> null
             }
         } catch (e: Exception) {
@@ -330,8 +330,8 @@ class Client() {
         return try {
             val conversation = ffiClient.conversation(conversationId.hexToByteArray())
             when (conversation.conversationType()) {
-                FfiConversationType.GROUP -> Conversation.Group(Group(this, conversation))
-                FfiConversationType.DM -> Conversation.Dm(Dm(this, conversation))
+                FfiConversationType.GROUP -> Conversation.Group(Group(this.inboxId, conversation))
+                FfiConversationType.DM -> Conversation.Dm(Dm(this.inboxId, conversation))
                 else -> null
             }
         } catch (e: Exception) {
@@ -341,7 +341,7 @@ class Client() {
 
     fun findDmByInboxId(inboxId: String): Dm? {
         return try {
-            Dm(this, ffiClient.dmConversation(inboxId))
+            Dm(this.inboxId, ffiClient.dmConversation(inboxId))
         } catch (e: Exception) {
             null
         }

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -141,14 +141,6 @@ sealed class Conversation {
         }
     }
 
-    val client: Client
-        get() {
-            return when (this) {
-                is Group -> group.client
-                is Dm -> dm.client
-            }
-        }
-
     fun streamMessages(): Flow<Message> {
         return when (this) {
             is Group -> group.streamMessages()

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -42,8 +42,8 @@ data class Conversations(
     suspend fun fromWelcome(envelopeBytes: ByteArray): Conversation {
         val conversation = ffiConversations.processStreamedWelcomeMessage(envelopeBytes)
         return when (conversation.conversationType()) {
-            FfiConversationType.DM -> Conversation.Dm(Dm(client, conversation))
-            else -> Conversation.Group(Group(client, conversation))
+            FfiConversationType.DM -> Conversation.Dm(Dm(client.inboxId, conversation))
+            else -> Conversation.Group(Group(client.inboxId, conversation))
         }
     }
 
@@ -118,7 +118,7 @@ data class Conversations(
                     customPermissionPolicySet = permissionsPolicySet
                 )
             )
-        return Group(client, group)
+        return Group(client.inboxId, group)
     }
 
     // Sync from the network the latest list of conversations
@@ -152,7 +152,7 @@ data class Conversations(
         var dm = client.findDmByAddress(peerAddress)
         if (dm == null) {
             val dmConversation = ffiConversations.createDm(peerAddress.lowercase())
-            dm = Dm(client, dmConversation)
+            dm = Dm(client.inboxId, dmConversation)
         }
         return dm
     }
@@ -174,7 +174,7 @@ data class Conversations(
         )
 
         return ffiGroups.map {
-            Group(client, it.conversation(), it.lastMessage())
+            Group(client.inboxId, it.conversation(), it.lastMessage())
         }
     }
 
@@ -195,7 +195,7 @@ data class Conversations(
         )
 
         return ffiDms.map {
-            Dm(client, it.conversation(), it.lastMessage())
+            Dm(client.inboxId, it.conversation(), it.lastMessage())
         }
     }
 
@@ -220,8 +220,8 @@ data class Conversations(
 
     private suspend fun FfiConversationListItem.toConversation(): Conversation {
         return when (conversation().conversationType()) {
-            FfiConversationType.DM -> Conversation.Dm(Dm(client, conversation(), lastMessage()))
-            else -> Conversation.Group(Group(client, conversation(), lastMessage()))
+            FfiConversationType.DM -> Conversation.Dm(Dm(client.inboxId, conversation(), lastMessage()))
+            else -> Conversation.Group(Group(client.inboxId, conversation(), lastMessage()))
         }
     }
 
@@ -234,13 +234,13 @@ data class Conversations(
                             FfiConversationType.DM -> trySend(
                                 Conversation.Dm(
                                     Dm(
-                                        client,
+                                        client.inboxId,
                                         conversation
                                     )
                                 )
                             )
 
-                            else -> trySend(Conversation.Group(Group(client, conversation)))
+                            else -> trySend(Conversation.Group(Group(client.inboxId, conversation)))
                         }
                     }
                 }

--- a/library/src/main/java/org/xmtp/android/library/Dm.kt
+++ b/library/src/main/java/org/xmtp/android/library/Dm.kt
@@ -22,7 +22,7 @@ import uniffi.xmtpv3.FfiMessageCallback
 import uniffi.xmtpv3.FfiSubscribeException
 import java.util.Date
 
-class Dm(val client: Client, private val libXMTPGroup: FfiConversation, private val ffiLastMessage: FfiMessage? = null) {
+class Dm(private val clientInboxId: String, private val libXMTPGroup: FfiConversation, private val ffiLastMessage: FfiMessage? = null) {
     val id: String
         get() = libXMTPGroup.id().toHex()
 
@@ -150,7 +150,7 @@ class Dm(val client: Client, private val libXMTPGroup: FfiConversation, private 
     }
 
     suspend fun isCreator(): Boolean {
-        return metadata().creatorInboxId() == client.inboxId
+        return metadata().creatorInboxId() == clientInboxId
     }
 
     suspend fun members(): List<Member> {

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -29,7 +29,7 @@ import uniffi.xmtpv3.FfiSubscribeException
 import java.util.Date
 
 class Group(
-    val client: Client,
+    private val clientInboxId: String,
     private val libXMTPGroup: FfiConversation,
     private val ffiLastMessage: FfiMessage? = null,
 ) {
@@ -193,7 +193,7 @@ class Group(
     }
 
     suspend fun isCreator(): Boolean {
-        return metadata().creatorInboxId() == client.inboxId
+        return metadata().creatorInboxId() == clientInboxId
     }
 
     suspend fun addMembers(addresses: List<String>) {
@@ -234,7 +234,7 @@ class Group(
 
     suspend fun peerInboxIds(): List<String> {
         val ids = members().map { it.inboxId }.toMutableList()
-        ids.remove(client.inboxId)
+        ids.remove(clientInboxId)
         return ids
     }
 


### PR DESCRIPTION
It would be nicer if Conversations did not require a client so that they could be better serialized in apps.