### PR TITLE
Clean up redundant consent code

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -169,7 +169,7 @@ data class Conversations(
         return dm
     }
 
-    suspend fun listGroups(
+    fun listGroups(
         after: Date? = null,
         before: Date? = null,
         limit: Int? = null,
@@ -190,7 +190,7 @@ data class Conversations(
         }
     }
 
-    suspend fun listDms(
+    fun listDms(
         after: Date? = null,
         before: Date? = null,
         limit: Int? = null,

--- a/library/src/main/java/org/xmtp/android/library/Dm.kt
+++ b/library/src/main/java/org/xmtp/android/library/Dm.kt
@@ -49,9 +49,6 @@ class Dm(private val clientInboxId: String, private val libXMTPGroup: FfiConvers
     }
 
     suspend fun send(encodedContent: EncodedContent): String {
-        if (consentState() == ConsentState.UNKNOWN) {
-            updateConsentState(ConsentState.ALLOWED)
-        }
         val messageId = libXMTPGroup.send(contentBytes = encodedContent.toByteArray())
         return messageId.toHex()
     }
@@ -81,16 +78,10 @@ class Dm(private val clientInboxId: String, private val libXMTPGroup: FfiConvers
     }
 
     fun prepareMessage(encodedContent: EncodedContent): String {
-        if (consentState() == ConsentState.UNKNOWN) {
-            updateConsentState(ConsentState.ALLOWED)
-        }
         return libXMTPGroup.sendOptimistic(encodedContent.toByteArray()).toHex()
     }
 
     fun <T> prepareMessage(content: T, options: SendOptions? = null): String {
-        if (consentState() == ConsentState.UNKNOWN) {
-            updateConsentState(ConsentState.ALLOWED)
-        }
         val encodeContent = encodeContent(content = content, options = options)
         return libXMTPGroup.sendOptimistic(encodeContent.toByteArray()).toHex()
     }

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -71,9 +71,6 @@ class Group(
     }
 
     suspend fun send(encodedContent: EncodedContent): String {
-        if (consentState() == ConsentState.UNKNOWN) {
-            updateConsentState(ConsentState.ALLOWED)
-        }
         val messageId = libXMTPGroup.send(contentBytes = encodedContent.toByteArray())
         return messageId.toHex()
     }
@@ -103,16 +100,10 @@ class Group(
     }
 
     fun prepareMessage(encodedContent: EncodedContent): String {
-        if (consentState() == ConsentState.UNKNOWN) {
-            updateConsentState(ConsentState.ALLOWED)
-        }
         return libXMTPGroup.sendOptimistic(encodedContent.toByteArray()).toHex()
     }
 
     fun <T> prepareMessage(content: T, options: SendOptions? = null): String {
-        if (consentState() == ConsentState.UNKNOWN) {
-            updateConsentState(ConsentState.ALLOWED)
-        }
         val encodeContent = encodeContent(content = content, options = options)
         return libXMTPGroup.sendOptimistic(encodeContent.toByteArray()).toHex()
     }


### PR DESCRIPTION
Removes consent set on send message as it's handled in libxmtp.