### PR TITLE
Make addWallet a delicate API

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -5,7 +5,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
 import org.junit.Test

--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
 import org.junit.Test
@@ -517,6 +518,7 @@ class ClientTest {
         )
     }
 
+    @OptIn(DelicateApi::class)
     @Test
     fun testAddAccounts() {
         val fixtures = fixtures()
@@ -539,6 +541,29 @@ class ClientTest {
         )
     }
 
+    @OptIn(DelicateApi::class)
+    @Test
+    fun testAddAccountsWithExistingInboxIds() {
+        val fixtures = fixtures()
+
+        assertThrows(
+            "This wallet is already associated with inbox ${fixtures.boClient.inboxId}",
+            XMTPException::class.java
+        ) {
+            runBlocking { fixtures.alixClient.addAccount(fixtures.boAccount) }
+        }
+
+        assert(fixtures.boClient.inboxId != fixtures.alixClient.inboxId)
+        runBlocking { fixtures.alixClient.addAccount(fixtures.boAccount, true) }
+
+        val state = runBlocking { fixtures.alixClient.inboxState(true) }
+        assertEquals(state.addresses.size, 2)
+
+        val inboxId = runBlocking { fixtures.alixClient.inboxIdFromAddress(fixtures.boClient.address) }
+        assertEquals(inboxId, fixtures.alixClient.inboxId)
+    }
+
+    @OptIn(DelicateApi::class)
     @Test
     fun testRemovingAccounts() {
         val fixtures = fixtures()

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -259,10 +259,11 @@ class Client() {
     }
 
     @DelicateApi("This function is delicate and should be used with caution. Adding a wallet already associated with an inboxId will cause the wallet to loose access to that inbox. See: inboxIdFromAddress(address)")
-    suspend fun addAccount(newAccount: SigningKey, changeInboxId: Boolean = false) {
-        val inboxId: String? = if (!changeInboxId) inboxIdFromAddress(newAccount.address) else null
+    suspend fun addAccount(newAccount: SigningKey, allowReassignInboxId: Boolean = false) {
+        val inboxId: String? =
+            if (!allowReassignInboxId) inboxIdFromAddress(newAccount.address) else null
 
-        if (changeInboxId || inboxId.isNullOrBlank()) {
+        if (allowReassignInboxId || inboxId.isNullOrBlank()) {
             val signatureRequest = ffiClient.addWallet(newAccount.address.lowercase())
             handleSignature(signatureRequest, newAccount)
             ffiClient.applySignatureRequest(signatureRequest)

--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -260,10 +260,10 @@ class Client() {
 
     @DelicateApi("This function is delicate and should be used with caution. Adding a wallet already associated with an inboxId will cause the wallet to loose access to that inbox. See: inboxIdFromAddress(address)")
     suspend fun addAccount(newAccount: SigningKey, changeInboxId: Boolean = false) {
-        val inboxId = inboxIdFromAddress(newAccount.address)
-        if (inboxId.isNullOrBlank() || changeInboxId) {
-            val signatureRequest =
-                ffiClient.addWallet(newAccount.address.lowercase())
+        val inboxId: String? = if (!changeInboxId) inboxIdFromAddress(newAccount.address) else null
+
+        if (changeInboxId || inboxId.isNullOrBlank()) {
+            val signatureRequest = ffiClient.addWallet(newAccount.address.lowercase())
             handleSignature(signatureRequest, newAccount)
             ffiClient.applySignatureRequest(signatureRequest)
         } else {

--- a/library/src/main/java/org/xmtp/android/library/DelicateApi.kt
+++ b/library/src/main/java/org/xmtp/android/library/DelicateApi.kt
@@ -1,0 +1,6 @@
+package org.xmtp.android.library
+
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class DelicateApi(val message: String)


### PR DESCRIPTION
Require a boolean to be passed to allow overriding an existing inboxId when calling `addWallet`. Also makes a new annotation for delicate Apis.