### PR TITLE
Add paused for min version function

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
@@ -1165,4 +1165,17 @@ class GroupTest {
         assert(boGroup.isDisappearingMessagesEnabled)
         assert(alixGroup.isDisappearingMessagesEnabled)
     }
+
+    @Test
+    fun testGroupPausedForVersionReturnsNone() = runBlocking {
+        val boGroup = boClient.conversations.newGroup(
+            listOf(alixClient.inboxId)
+        )
+        val pausedForVersionGroup = boGroup.pausedForVersion()
+        assertNull(pausedForVersionGroup)
+
+        val boDm = boClient.conversations.newConversation(alixClient.inboxId)
+        val pausedForVersionDm = boDm.pausedForVersion()
+        assertNull(pausedForVersionDm)
+    }
 }

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -192,6 +192,14 @@ sealed class Conversation {
         }
     }
 
+    // Returns null if conversation is not paused, otherwise the min version required to unpause this conversation
+    fun pausedForVersion(): String? {
+        return when (this) {
+            is Group -> group.pausedForVersion()
+            is Dm -> dm.pausedForVersion()
+        }
+    }
+
     val client: Client
         get() {
             return when (this) {

--- a/library/src/main/java/org/xmtp/android/library/Dm.kt
+++ b/library/src/main/java/org/xmtp/android/library/Dm.kt
@@ -264,4 +264,9 @@ class Dm(
     fun consentState(): ConsentState {
         return ConsentState.fromFfiConsentState(libXMTPGroup.consentState())
     }
+
+    // Returns null if dm is not paused, otherwise the min version required to unpause this dm
+    fun pausedForVersion(): String? {
+        return libXMTPGroup.pausedForVersion()
+    }
 }

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -429,6 +429,11 @@ class Group(
         return libXMTPGroup.superAdminList()
     }
 
+    // Returns null if group is not paused, otherwise the min version required to unpause this group
+    fun pausedForVersion(): String? {
+        return libXMTPGroup.pausedForVersion()
+    }
+
     fun streamMessages(): Flow<DecodedMessage> = callbackFlow {
         val messageCallback = object : FfiMessageCallback {
             override fun onMessage(message: FfiMessage) {


### PR DESCRIPTION
For test branch simulating clients on different versions experiencing a paused group, see https://github.com/xmtp/xmtp-android/compare/cv/test-pause-for-min-version?expand=1