### PR TITLE
Add section on LLM based pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,25 @@ Submit feature requests as [GitHub Issues](https://github.com/xmtp/xmtp-android/
 
 PRs are encouraged, but consider starting with a feature request to temperature-check first. If the PR involves a major change to the protocol, the work should be fleshed out as an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) before work begins.
 
+### AI-Generated Contributions Policy
+
+We do not accept pull requests that are generated entirely or primarily by AI/LLM tools (e.g., GitHub Copilot, ChatGPT, Claude). This includes:
+
+- Automated typo fixes or formatting changes
+- Generic code improvements without context
+- Mass automated updates or refactoring
+
+Pull requests that appear to be AI-generated without meaningful human oversight will be closed without review. We value human-driven, thoughtful contributions that demonstrate an understanding of the codebase and project goals.
+
+> [!CAUTION]
+> To protect project quality and maintain contributor trust, we will restrict access for users who continue to submit AI-generated pull requests.
+
+If you use AI tools to assist your development process, please:
+
+1. Thoroughly review and understand all generated code
+2. Provide detailed PR descriptions explaining your changes and reasoning
+3. Be prepared to discuss your implementation decisions and how they align with the project goals
+
 ## 🔧 Developing
 
 ### Prerequisites


### PR DESCRIPTION
# Summary

To clarify our stance on LLM-based pull requests, this PR adds a section to the contributing guide that we can reference when closing pull requests that violate this policy.