### PR TITLE
docs(readme): added link to Lint and Test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # xmtp-android
 
-![Test](https://github.com/xmtp/xmtp-android/actions/workflows/test.yml/badge.svg) ![Lint](https://github.com/xmtp/xmtp-android/actions/workflows/lint.yml/badge.svg) ![Status](https://img.shields.io/badge/Feature_status-Alpha-orange)
+[![Test](https://github.com/xmtp/xmtp-android/actions/workflows/test.yml/badge.svg)](https://github.com/xmtp/xmtp-android/actions/workflows/test.yml) 
+[![Lint](https://github.com/xmtp/xmtp-android/actions/workflows/lint.yml/badge.svg)](https://github.com/xmtp/xmtp-android/actions/workflows/lint.yml) 
+![Status](https://img.shields.io/badge/Feature_status-Alpha-orange)
 
 `xmtp-android` provides a Kotlin implementation of an XMTP message API client for use with Android apps.
 


### PR DESCRIPTION
## docs: Add workflow links to README badges
Added clickable links to the Test and Lint badges in README.md that direct to their respective GitHub Actions workflow pages

### 📍Where to Start
The changes are in [README.md](https://github.com/xmtp/xmtp-android/pull/404/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R0) where the badge markdown has been modified to include workflow links

----

_[Macroscope](https://app.macroscope.com) summarized c9c5859._