### PR TITLE
chore: added links to Test and Lint badges and added a new CodeQL badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xmtp-android
 
-![Test](https://github.com/xmtp/xmtp-android/actions/workflows/test.yml/badge.svg) ![Lint](https://github.com/xmtp/xmtp-android/actions/workflows/lint.yml/badge.svg)
+[![Test](https://github.com/xmtp/xmtp-android/actions/workflows/test.yml/badge.svg)](https://github.com/xmtp/xmtp-android/actions/workflows/test.yml) [![Lint](https://github.com/xmtp/xmtp-android/actions/workflows/lint.yml/badge.svg)](https://github.com/xmtp/xmtp-android/actions/workflows/lint.yml) [![CodeQL](https://github.com/xmtp/xmtp-android/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/xmtp/xmtp-android/actions/workflows/github-code-scanning/codeql)
 
 `xmtp-android` provides a Kotlin implementation of an XMTP message API client for use with Android apps.
 


### PR DESCRIPTION
### Add clickable links to status badges and introduce CodeQL badge in README
Updates the status badges section in [README.md](https://github.com/xmtp/xmtp-android/pull/426/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) by making the existing Test and Lint badges clickable with links to their respective GitHub Actions workflows, and adds a new CodeQL badge that links to the code scanning workflow.

#### 📍Where to Start
Begin the review with [README.md](https://github.com/xmtp/xmtp-android/pull/426/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) which contains all the badge modifications.

----

_[Macroscope](https://app.macroscope.com) summarized e7e1202._