### PR TITLE
Fix Unable to open the database file 

### DIFF
--- a/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -366,7 +366,13 @@ class Client(
             } else {
                 File(appContext.filesDir.absolutePath, "xmtp_db")
             }
-            directoryFile.mkdir()
+
+            if (!directoryFile.exists()) {
+                val created = directoryFile.mkdirs()
+                if (!created) {
+                    throw XMTPException("Failed to create directory for database at ${directoryFile.absolutePath}")
+                }
+            }
             val dbPath = directoryFile.absolutePath + "/$alias.db3"
 
             val ffiClient = createClient(


### PR DESCRIPTION
Should fix

```
Error Call to function 'XMTP.ffiCreateClient' has been rejected.
→ Caused by: uniffi.xmtpv3.GenericException$Storage: Storage error: Unable to open the database file 
```

mkdir will only make the last directory where as we want to make all the directories in the path so mkdirs is more appropriate.