### PR TITLE
fix claude api key param

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,7 +36,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@beta
         with:
-          claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           model: "claude-opus-4-1-20250805"
 


### PR DESCRIPTION
### Fix the Claude API key parameter by changing the `with` input from `claude_code_oauth_token` to `anthropic_api_key` in [claude-review.yml](https://github.com/xmtp/xmtp-android/pull/465/files#diff-a16b9cfdaf9b59acd95f3f8af7be93c559d14c7e581e809acdc53106fb73971e) for the `anthropics/claude-code-action@beta` step
Update [claude-review.yml](https://github.com/xmtp/xmtp-android/pull/465/files#diff-a16b9cfdaf9b59acd95f3f8af7be93c559d14c7e581e809acdc53106fb73971e) to adjust the `with` block for the `anthropics/claude-code-action@beta` step, retaining the value `${{ secrets.ANTHROPIC_API_KEY }}` and modifying only the input key.

#### 📍Where to Start
Start with the `anthropics/claude-code-action@beta` step’s `with` block in [claude-review.yml](https://github.com/xmtp/xmtp-android/pull/465/files#diff-a16b9cfdaf9b59acd95f3f8af7be93c559d14c7e581e809acdc53106fb73971e).

----

_[Macroscope](https://app.macroscope.com) summarized 40efbee._