### PR TITLE
Rename to enrichedMessages

### DIFF
--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -1053,7 +1053,6 @@ class ClientTest {
         println("Aggregate Stats Create:\n$aggregateStats2")
 
         val apiStats2 = alix.debugInformation.apiStatistics
-        assertEquals(0, apiStats2.uploadKeyPackage)
         assertEquals(0, apiStats2.fetchKeyPackage)
         assertEquals(6, apiStats2.sendGroupMessages)
         assertEquals(0, apiStats2.sendWelcomeMessages)

--- a/library/src/androidTest/java/org/xmtp/android/library/DecodedMessageV2Test.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/DecodedMessageV2Test.kt
@@ -48,7 +48,7 @@ class DecodedMessageV2Test {
     }
 
     @Test
-    fun testCanRetrieveMessagesV2FromGroup() {
+    fun testCanRetrieveEnrichedMessagesFromGroup() {
         val boGroup = runBlocking {
             boClient.conversations.newGroup(listOf(alixClient.inboxId))
         }
@@ -65,7 +65,7 @@ class DecodedMessageV2Test {
         }
 
         val messagesV2 = runBlocking {
-            boGroup.messagesV2()
+            boGroup.enrichedMessages()
         }
 
         // Groups include a GroupUpdated message when members are added
@@ -94,7 +94,7 @@ class DecodedMessageV2Test {
         }
 
         val messagesV2 = runBlocking {
-            boDm.messagesV2()
+            boDm.enrichedMessages()
         }
 
         // DMs include a GroupUpdated message when the conversation is created
@@ -124,17 +124,17 @@ class DecodedMessageV2Test {
         }
 
         val limitedMessages = runBlocking {
-            boGroup.messagesV2(limit = 5)
+            boGroup.enrichedMessages(limit = 5)
         }
         assertEquals(5, limitedMessages.size)
 
         val beforeMessages = runBlocking {
-            boGroup.messagesV2(beforeNs = limitedMessages[2].sentAtNs)
+            boGroup.enrichedMessages(beforeNs = limitedMessages[2].sentAtNs)
         }
         assertTrue(beforeMessages.all { it.sentAtNs < limitedMessages[2].sentAtNs })
 
         val afterMessages = runBlocking {
-            boGroup.messagesV2(afterNs = limitedMessages[2].sentAtNs)
+            boGroup.enrichedMessages(afterNs = limitedMessages[2].sentAtNs)
         }
         assertTrue(afterMessages.all { it.sentAtNs > limitedMessages[2].sentAtNs })
     }
@@ -158,7 +158,7 @@ class DecodedMessageV2Test {
         }
 
         val descendingMessages = runBlocking {
-            boGroup.messagesV2(direction = DecodedMessage.SortDirection.DESCENDING)
+            boGroup.enrichedMessages(direction = DecodedMessage.SortDirection.DESCENDING)
         }
         // Skip GroupUpdated message, check text messages
         assertEquals("Third message", descendingMessages[0].content<String>())
@@ -166,7 +166,7 @@ class DecodedMessageV2Test {
         assertEquals("First message", descendingMessages[2].content<String>())
 
         val ascendingMessages = runBlocking {
-            boGroup.messagesV2(direction = DecodedMessage.SortDirection.ASCENDING)
+            boGroup.enrichedMessages(direction = DecodedMessage.SortDirection.ASCENDING)
         }
         // First message is GroupUpdated, then text messages
         assertNotNull(ascendingMessages[0].content<Any>()) // GroupUpdated
@@ -191,20 +191,20 @@ class DecodedMessageV2Test {
         }
 
         val allMessages = runBlocking {
-            boGroup.messagesV2(deliveryStatus = DecodedMessage.MessageDeliveryStatus.ALL)
+            boGroup.enrichedMessages(deliveryStatus = DecodedMessage.MessageDeliveryStatus.ALL)
         }
         // 2 user messages + 1 GroupUpdated message
         assertEquals(3, allMessages.size)
 
         val publishedMessages = runBlocking {
-            boGroup.messagesV2(deliveryStatus = DecodedMessage.MessageDeliveryStatus.PUBLISHED)
+            boGroup.enrichedMessages(deliveryStatus = DecodedMessage.MessageDeliveryStatus.PUBLISHED)
         }
         // 1 published user message + 1 GroupUpdated message
         assertEquals(2, publishedMessages.size)
         assertEquals("Published message", publishedMessages[0].content<String>())
 
         val unpublishedMessages = runBlocking {
-            boGroup.messagesV2(deliveryStatus = DecodedMessage.MessageDeliveryStatus.UNPUBLISHED)
+            boGroup.enrichedMessages(deliveryStatus = DecodedMessage.MessageDeliveryStatus.UNPUBLISHED)
         }
         assertEquals(1, unpublishedMessages.size)
         assertEquals("Unpublished message", unpublishedMessages[0].content<String>())
@@ -223,8 +223,8 @@ class DecodedMessageV2Test {
             options = SendOptions(contentType = NumberCodec().contentType),
         )
 
-        val messages = group.messagesV2()
-        val content: Double? = messages[0].content()
+        val messages = group.enrichedMessages()
+        val content: Double? = messages[0].content<Double>()
         assertEquals(myNumber, content)
     }
 
@@ -268,7 +268,7 @@ class DecodedMessageV2Test {
         }
 
         val messagesV2 = runBlocking {
-            boGroup.messagesV2()
+            boGroup.enrichedMessages()
         }
 
         val messageWithReactions =
@@ -315,7 +315,7 @@ class DecodedMessageV2Test {
         }
 
         val messagesV2 = runBlocking {
-            boGroup.messagesV2()
+            boGroup.enrichedMessages()
         }
 
         val message = messagesV2.find { it.content<String>() == "Test reaction count" }

--- a/library/src/androidTest/java/org/xmtp/android/library/MessageComparisonTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/MessageComparisonTest.kt
@@ -78,7 +78,7 @@ class MessageComparisonTest {
         }
 
         val messagesV2 = runBlocking {
-            boGroup.messagesV2()
+            boGroup.enrichedMessages()
         }
 
         // V1 also includes system messages now, so filter for text messages only
@@ -169,7 +169,7 @@ class MessageComparisonTest {
         }
 
         val messagesV2 = runBlocking {
-            boGroup.messagesV2(direction = DecodedMessage.SortDirection.ASCENDING)
+            boGroup.enrichedMessages(direction = DecodedMessage.SortDirection.ASCENDING)
         }
 
         // V2 includes GroupUpdated message at the beginning, filter to text messages only
@@ -253,7 +253,7 @@ class MessageComparisonTest {
 
         val v2StartTime = System.currentTimeMillis()
         val messagesV2 = runBlocking {
-            boGroup.messagesV2()
+            boGroup.enrichedMessages()
         }
         val v2EndTime = System.currentTimeMillis()
         val v2Duration = v2EndTime - v2StartTime
@@ -262,7 +262,10 @@ class MessageComparisonTest {
         println("V2 fetch time: ${v2Duration}ms for ${messagesV2.size} messages (excluding embedded reactions)")
 
         val v2MessagesWithReactions = messagesV2.filter { it.hasReactions }
-        assertTrue("V2 should include messages with embedded reactions", v2MessagesWithReactions.isNotEmpty())
+        assertTrue(
+            "V2 should include messages with embedded reactions",
+            v2MessagesWithReactions.isNotEmpty()
+        )
     }
 
     @Test
@@ -309,7 +312,7 @@ class MessageComparisonTest {
         }
 
         val messagesV2 = runBlocking {
-            boGroup.messagesV2()
+            boGroup.enrichedMessages()
         }
 
         // V1 messages include reactions as separate messages

--- a/library/src/androidTest/java/org/xmtp/android/library/ReplyTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ReplyTest.kt
@@ -84,7 +84,7 @@ class ReplyTest {
             aliceGroup.sync()
         }
 
-        val messagesV2 = runBlocking { aliceGroup.messagesV2() }
+        val messagesV2 = runBlocking { aliceGroup.enrichedMessages() }
         // 2 user messages + 1 GroupUpdated message
         assertEquals(3, messagesV2.size)
 
@@ -126,7 +126,7 @@ class ReplyTest {
             aliceGroup.sync()
         }
 
-        val messagesV2 = runBlocking { aliceGroup.messagesV2() }
+        val messagesV2 = runBlocking { aliceGroup.enrichedMessages() }
         // 1 user message + 1 GroupUpdated message
         assertEquals(2, messagesV2.size)
 
@@ -170,7 +170,7 @@ class ReplyTest {
             aliceGroup.sync()
         }
 
-        val messagesV2 = runBlocking { aliceGroup.messagesV2() }
+        val messagesV2 = runBlocking { aliceGroup.enrichedMessages() }
         // 2 user messages + 1 GroupUpdated message
         assertEquals(3, messagesV2.size)
 

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -184,7 +184,7 @@ sealed class Conversation {
         }
     }
 
-    suspend fun messagesV2(
+    suspend fun enrichedMessages(
         limit: Int? = null,
         beforeNs: Long? = null,
         afterNs: Long? = null,
@@ -192,8 +192,8 @@ sealed class Conversation {
         deliveryStatus: DecodedMessage.MessageDeliveryStatus = DecodedMessage.MessageDeliveryStatus.ALL,
     ): List<DecodedMessageV2> {
         return when (this) {
-            is Group -> group.messagesV2(limit, beforeNs, afterNs, direction, deliveryStatus)
-            is Dm -> dm.messagesV2(limit, beforeNs, afterNs, direction, deliveryStatus)
+            is Group -> group.enrichedMessages(limit, beforeNs, afterNs, direction, deliveryStatus)
+            is Dm -> dm.enrichedMessages(limit, beforeNs, afterNs, direction, deliveryStatus)
         }
     }
 

--- a/library/src/main/java/org/xmtp/android/library/Conversations.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversations.kt
@@ -115,11 +115,11 @@ data class Conversations(
         }
     }
 
-    fun findMessageV2(messageId: String): DecodedMessageV2? {
+    fun findEnrichedMessage(messageId: String): DecodedMessageV2? {
         return try {
             DecodedMessageV2.create(ffiClient.messageV2(messageId.hexToByteArray()))
         } catch (e: Exception) {
-            Log.e("findMessageV2 failed", e.toString())
+            Log.e("findEnrichedMessage failed", e.toString())
             null
         }
     }

--- a/library/src/main/java/org/xmtp/android/library/Dm.kt
+++ b/library/src/main/java/org/xmtp/android/library/Dm.kt
@@ -199,7 +199,7 @@ class Dm(
         }
     }
 
-    suspend fun messagesV2(
+    suspend fun enrichedMessages(
         limit: Int? = null,
         beforeNs: Long? = null,
         afterNs: Long? = null,

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -215,7 +215,7 @@ class Group(
         }
     }
 
-    suspend fun messagesV2(
+    suspend fun enrichedMessages(
         limit: Int? = null,
         beforeNs: Long? = null,
         afterNs: Long? = null,


### PR DESCRIPTION
### Rename message retrieval APIs and tests to `enrichedMessages` across `Group`, `Dm`, `Conversation`, and `Conversations` to align with the "Rename to enrichedMessages" purpose
This change renames the `messagesV2` API and related helpers to `enrichedMessages` across the core conversation types and updates all corresponding Android instrumentation tests. It also updates a log message and removes a single assertion in a client test.

- Rename `Group.messagesV2` to `Group.enrichedMessages` and keep the same signature in [Group.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-0bc942e458f483ac87a55f0bd8d9ee89abc0a03d9cca7fe44d8081acf2749c5b)
- Rename `Dm.messagesV2` to `Dm.enrichedMessages` and keep the same signature in [Dm.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-5221bfec9e9bb6a23945941677af4e18af500b41e47b6a4fb6d75a26b45359a6)
- Rename `Conversation.messagesV2` to `Conversation.enrichedMessages` with internal dispatch updated in [Conversation.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-e5f667529c5e94c317bb484d5229352677d7b7636451fb2f1437d0b93c0beabf)
- Rename `Conversations.findMessageV2` to `Conversations.findEnrichedMessage` and adjust log tag/message in [Conversations.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-479fe53ececf1836cd910bfba9a721b20fce9fd212b204329abef95ff79429f9)
- Update tests to use `enrichedMessages` and adjust one content extraction to `messages[0].content<Double>()` in [DecodedMessageV2Test.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-196d2992e5877d5b5ea2a63b8bf882561d5eea50ba106a3784bf1ff25bad0e2a), [MessageComparisonTest.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-502f515d72a2574033be9c9e82caa34e4f643b88c2553c63afa7fb32722760a7), and [ReplyTest.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-3428c7dca689f0b1178ef0390bcdd05c73713556f81dfdac619c9e090152a09e)
- Remove an assertion for `apiStats2.uploadKeyPackage == 0` in [ClientTest.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-9db3ddde4f7fb6f454ed9571b63c4d1e4b02163d97ca1e156178f004b26b3356)

#### 📍Where to Start
Start with the API rename surfaces in [Conversation.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-e5f667529c5e94c317bb484d5229352677d7b7636451fb2f1437d0b93c0beabf), then review the concrete implementations in [Group.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-0bc942e458f483ac87a55f0bd8d9ee89abc0a03d9cca7fe44d8081acf2749c5b) and [Dm.kt](https://github.com/xmtp/xmtp-android/pull/470/files#diff-5221bfec9e9bb6a23945941677af4e18af500b41e47b6a4fb6d75a26b45359a6).

----

_[Macroscope](https://app.macroscope.com) summarized c1f4c64._