### PR TITLE
functions that use db should default to dispatchers io

### DIFF
--- a/example/src/main/java/org/xmtp/android/example/MainViewModel.kt
+++ b/example/src/main/java/org/xmtp/android/example/MainViewModel.kt
@@ -46,6 +46,8 @@ class MainViewModel : ViewModel() {
             val listItems = mutableListOf<MainListItem>()
             try {
                 val conversations = ClientManager.client.conversations
+                // Ensure we fetch the latest conversations from the network before listing
+                conversations.sync()
                 val subscriptions = conversations.allPushTopics().map {
                     val hmacKeysResult = ClientManager.client.conversations.getHmacKeys()
                     val hmacKeys = hmacKeysResult.hmacKeysMap

--- a/library/src/androidTest/java/org/xmtp/android/library/ArchiveTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ArchiveTest.kt
@@ -156,9 +156,9 @@ class ArchiveTest {
         }
         val convosList = runBlocking { alixClient2.conversations.list() }
         assertEquals(1, convosList.size)
-        assertEquals(convosList.first().isActive(), false)
+        assertEquals(runBlocking { convosList.first().isActive() }, false)
         val dm2 = runBlocking { alixClient.conversations.findOrCreateDm(fixtures.boClient.inboxId) }
-        assertEquals(dm2.isActive(), true)
+        assertEquals(runBlocking { dm2.isActive() }, true)
 
         runBlocking {
             boDm.send("hey")

--- a/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -214,7 +214,7 @@ class ClientTest {
         }
 
         assert(client.dbPath.isNotEmpty())
-        client.deleteLocalDatabase()
+        runBlocking { client.deleteLocalDatabase() }
 
         client = runBlocking {
             Client.create(
@@ -336,7 +336,7 @@ class ClientTest {
             assertEquals(boClient.conversations.listGroups().size, 1)
         }
 
-        boClient.dropLocalDatabaseConnection()
+        runBlocking { boClient.dropLocalDatabaseConnection() }
 
         assertThrows(
             "Client error: storage error: Pool needs to  reconnect before use",
@@ -621,7 +621,7 @@ class ClientTest {
             ),
             true
         )
-        fixtures.alixClient.deleteLocalDatabase()
+        runBlocking { fixtures.alixClient.deleteLocalDatabase() }
 
         val key = SecureRandom().generateSeed(32)
         val context = InstrumentationRegistry.getInstrumentation().targetContext

--- a/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
@@ -60,9 +60,9 @@ class ConversationsTest {
 
     @Test
     fun testCanCreateOptimisticGroup() {
-        val optimisticGroup = boClient.conversations.newGroupOptimistic(groupName = "Testing")
+        val optimisticGroup = runBlocking { boClient.conversations.newGroupOptimistic(groupName = "Testing") }
         assertEquals(optimisticGroup.name, "Testing")
-        optimisticGroup.prepareMessage("testing")
+        runBlocking { optimisticGroup.prepareMessage("testing") }
         assertEquals(runBlocking { optimisticGroup.messages() }.size, 1)
 
         runBlocking {
@@ -282,9 +282,11 @@ class ConversationsTest {
             runBlocking { boClient.conversations.newGroup(listOf(alixClient.inboxId)) }
         val blockedConversation =
             runBlocking { boClient.conversations.findOrCreateDm(alixClient.inboxId) }
-        blockedGroup.updateConsentState(ConsentState.DENIED)
-        blockedConversation.updateConsentState(ConsentState.DENIED)
-        runBlocking { boClient.conversations.sync() }
+        runBlocking {
+            blockedGroup.updateConsentState(ConsentState.DENIED)
+            blockedConversation.updateConsentState(ConsentState.DENIED)
+            boClient.conversations.sync()
+        }
 
         val allMessages = mutableListOf<DecodedMessage>()
 
@@ -347,7 +349,7 @@ class ConversationsTest {
                 )
             }
         }
-        val hmacKeys = alixClient.conversations.getHmacKeys()
+        val hmacKeys = runBlocking { alixClient.conversations.getHmacKeys() }
 
         val topics = hmacKeys.hmacKeysMap.keys
         conversations.forEach { convo ->
@@ -392,10 +394,10 @@ class ConversationsTest {
             eriClient.conversations.syncAllConversations()
         }
 
-        val allTopics = eriClient.conversations.allPushTopics()
+        val allTopics = runBlocking { eriClient.conversations.allPushTopics() }
         val conversations = runBlocking { eriClient.conversations.list() }
-        val allHmacKeys = eriClient.conversations.getHmacKeys()
-        val dmHmacKeys = dm1.getHmacKeys()
+        val allHmacKeys = runBlocking { eriClient.conversations.getHmacKeys() }
+        val dmHmacKeys = runBlocking { dm1.getHmacKeys() }
         val dmTopics = runBlocking { dm1.getPushTopics() }
 
         assertEquals(allTopics.size, 3)

--- a/library/src/androidTest/java/org/xmtp/android/library/GroupPermissionsTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/GroupPermissionsTest.kt
@@ -51,7 +51,7 @@ class GroupPermissionsTest {
     }
 
     @Test
-    fun testGroupCreatedWithCorrectAdminList() {
+    fun testGroupCreatedWithCorrectAdminList() = runBlocking {
         val boGroup = runBlocking { boClient.conversations.newGroup(listOf(alixClient.inboxId)) }
         runBlocking { alixClient.conversations.sync() }
         val alixGroup = runBlocking { alixClient.conversations.listGroups().first() }
@@ -75,7 +75,7 @@ class GroupPermissionsTest {
     }
 
     @Test
-    fun testGroupCanUpdateAdminList() {
+    fun testGroupCanUpdateAdminList() = runBlocking {
         val boGroup = runBlocking {
             boClient.conversations.newGroup(
                 listOf(
@@ -177,7 +177,7 @@ class GroupPermissionsTest {
     }
 
     @Test
-    fun testGroupCanUpdateSuperAdminList() {
+    fun testGroupCanUpdateSuperAdminList() = runBlocking {
         val boGroup = runBlocking {
             boClient.conversations.newGroup(
                 listOf(
@@ -322,7 +322,7 @@ class GroupPermissionsTest {
     }
 
     @Test
-    fun testCanUpdatePermissions() {
+    fun testCanUpdatePermissions() = runBlocking {
         val boGroup = runBlocking {
             boClient.conversations.newGroup(
                 listOf(
@@ -374,7 +374,7 @@ class GroupPermissionsTest {
     }
 
     @Test
-    fun canCreateGroupWithCustomPermissions() {
+    fun canCreateGroupWithCustomPermissions() = runBlocking {
         val permissionPolicySet = PermissionPolicySet(
             addMemberPolicy = PermissionOption.Admin,
             removeMemberPolicy = PermissionOption.Deny,
@@ -454,7 +454,7 @@ class GroupPermissionsTest {
     }
 
     @Test
-    fun canCreateGroupWithInboxIdCustomPermissions() {
+    fun canCreateGroupWithInboxIdCustomPermissions() = runBlocking {
         val permissionPolicySet = PermissionPolicySet(
             addMemberPolicy = PermissionOption.Admin,
             removeMemberPolicy = PermissionOption.Deny,

--- a/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/GroupTest.kt
@@ -93,12 +93,12 @@ class GroupTest {
         assertEquals(runBlocking { alixGroup.members().size }, 3)
         assertEquals(runBlocking { boGroup.members().size }, 3)
 
-        assertEquals(boGroup.permissionPolicySet().addMemberPolicy, PermissionOption.Allow)
-        assertEquals(alixGroup.permissionPolicySet().addMemberPolicy, PermissionOption.Allow)
-        assertEquals(boGroup.isSuperAdmin(boClient.inboxId), true)
-        assertEquals(boGroup.isSuperAdmin(alixClient.inboxId), false)
-        assertEquals(alixGroup.isSuperAdmin(boClient.inboxId), true)
-        assertEquals(alixGroup.isSuperAdmin(alixClient.inboxId), false)
+        assertEquals(runBlocking { boGroup.permissionPolicySet().addMemberPolicy }, PermissionOption.Allow)
+        assertEquals(runBlocking { alixGroup.permissionPolicySet().addMemberPolicy }, PermissionOption.Allow)
+        assertEquals(runBlocking { boGroup.isSuperAdmin(boClient.inboxId) }, true)
+        assertEquals(runBlocking { boGroup.isSuperAdmin(alixClient.inboxId) }, false)
+        assertEquals(runBlocking { alixGroup.isSuperAdmin(boClient.inboxId) }, true)
+        assertEquals(runBlocking { alixGroup.isSuperAdmin(alixClient.inboxId) }, false)
         // can not fetch creator ID. See https://github.com/xmtp/libxmtp/issues/788
 //       assert(boGroup.isCreator())
         assert(!runBlocking { alixGroup.isCreator() })
@@ -159,12 +159,12 @@ class GroupTest {
         assertEquals(runBlocking { alixGroup.members().size }, 2)
         assertEquals(runBlocking { boGroup.members().size }, 2)
 
-        assertEquals(boGroup.permissionPolicySet().addMemberPolicy, PermissionOption.Admin)
-        assertEquals(alixGroup.permissionPolicySet().addMemberPolicy, PermissionOption.Admin)
-        assertEquals(boGroup.isSuperAdmin(boClient.inboxId), true)
-        assertEquals(boGroup.isSuperAdmin(alixClient.inboxId), false)
-        assertEquals(alixGroup.isSuperAdmin(boClient.inboxId), true)
-        assertEquals(alixGroup.isSuperAdmin(alixClient.inboxId), false)
+        assertEquals(runBlocking { boGroup.permissionPolicySet().addMemberPolicy }, PermissionOption.Admin)
+        assertEquals(runBlocking { alixGroup.permissionPolicySet().addMemberPolicy }, PermissionOption.Admin)
+        assertEquals(runBlocking { boGroup.isSuperAdmin(boClient.inboxId) }, true)
+        assertEquals(runBlocking { boGroup.isSuperAdmin(alixClient.inboxId) }, false)
+        assertEquals(runBlocking { alixGroup.isSuperAdmin(boClient.inboxId) }, true)
+        assertEquals(runBlocking { alixGroup.isSuperAdmin(alixClient.inboxId) }, false)
         // can not fetch creator ID. See https://github.com/xmtp/libxmtp/issues/788
 //       assert(boGroup.isCreator())
         assert(!runBlocking { alixGroup.isCreator() })
@@ -208,12 +208,12 @@ class GroupTest {
         assertEquals(runBlocking { alixGroup.members().size }, 3)
         assertEquals(runBlocking { boGroup.members().size }, 3)
 
-        assertEquals(boGroup.permissionPolicySet().addMemberPolicy, PermissionOption.Allow)
-        assertEquals(alixGroup.permissionPolicySet().addMemberPolicy, PermissionOption.Allow)
-        assertEquals(boGroup.isSuperAdmin(boClient.inboxId), true)
-        assertEquals(boGroup.isSuperAdmin(alixClient.inboxId), false)
-        assertEquals(alixGroup.isSuperAdmin(boClient.inboxId), true)
-        assertEquals(alixGroup.isSuperAdmin(alixClient.inboxId), false)
+        assertEquals(runBlocking { boGroup.permissionPolicySet().addMemberPolicy }, PermissionOption.Allow)
+        assertEquals(runBlocking { alixGroup.permissionPolicySet().addMemberPolicy }, PermissionOption.Allow)
+        assertEquals(runBlocking { boGroup.isSuperAdmin(boClient.inboxId) }, true)
+        assertEquals(runBlocking { boGroup.isSuperAdmin(alixClient.inboxId) }, false)
+        assertEquals(runBlocking { alixGroup.isSuperAdmin(boClient.inboxId) }, true)
+        assertEquals(runBlocking { alixGroup.isSuperAdmin(alixClient.inboxId) }, false)
         assert(!runBlocking { alixGroup.isCreator() })
     }
 
@@ -430,14 +430,14 @@ class GroupTest {
         runBlocking { caroClient.conversations.sync() }
         val caroGroup = runBlocking { caroClient.conversations.listGroups().first() }
         runBlocking { caroGroup.sync() }
-        assert(caroGroup.isActive())
-        assert(group.isActive())
+        assert(runBlocking { caroGroup.isActive() })
+        assert(runBlocking { group.isActive() })
         runBlocking {
             group.removeMembers(listOf(caroClient.inboxId))
             caroGroup.sync()
         }
-        assert(group.isActive())
-        assert(!caroGroup.isActive())
+        assert(runBlocking { group.isActive() })
+        assert(!runBlocking { caroGroup.isActive() })
     }
 
     @Test
@@ -451,7 +451,7 @@ class GroupTest {
         }
         runBlocking { boClient.conversations.sync() }
         val boGroup = runBlocking { boClient.conversations.listGroups().first() }
-        assertEquals(boGroup.addedByInboxId(), alixClient.inboxId)
+        assertEquals(runBlocking { boGroup.addedByInboxId() }, alixClient.inboxId)
     }
 
     @Test
@@ -680,7 +680,7 @@ class GroupTest {
             group.send("howdy")
             group.send("gm")
         }
-        val message = boClient.conversations.findMessage(messageId)
+        val message = runBlocking { boClient.conversations.findMessage(messageId) }
         assertEquals(runBlocking { group.messages() }.size, 3)
         assertEquals(runBlocking { group.messages(afterNs = message?.sentAtNs) }.size, 0)
         runBlocking {
@@ -928,7 +928,7 @@ class GroupTest {
             )
         }
         runBlocking { alixClient.conversations.sync() }
-        val alixGroup = alixClient.conversations.findGroup(boGroup.id)
+        val alixGroup = runBlocking { alixClient.conversations.findGroup(boGroup.id) }
 
         assertEquals(alixGroup?.id, boGroup.id)
     }
@@ -945,9 +945,9 @@ class GroupTest {
         }
         val boMessageId = runBlocking { boGroup.send("Hello") }
         runBlocking { alixClient.conversations.sync() }
-        val alixGroup = alixClient.conversations.findGroup(boGroup.id)
+        val alixGroup = runBlocking { alixClient.conversations.findGroup(boGroup.id) }
         runBlocking { alixGroup?.sync() }
-        val alixMessage = alixClient.conversations.findMessage(boMessageId)
+        val alixMessage = runBlocking { alixClient.conversations.findMessage(boMessageId) }
 
         assertEquals(alixMessage?.id, boMessageId)
     }
@@ -963,7 +963,7 @@ class GroupTest {
             )
         }
         runBlocking { alixClient.conversations.sync() }
-        val alixGroup: Group = alixClient.conversations.findGroup(boGroup.id)!!
+        val alixGroup: Group = runBlocking { alixClient.conversations.findGroup(boGroup.id)!! }
         runBlocking { assertEquals(alixGroup.consentState(), ConsentState.UNKNOWN) }
         val preparedMessageId = runBlocking { alixGroup.prepareMessage("Test text") }
         assertEquals(runBlocking { alixGroup.messages() }.size, 2)
@@ -1013,8 +1013,8 @@ class GroupTest {
             )
         }
         runBlocking { alixClient.conversations.sync() }
-        val alixGroup: Group = alixClient.conversations.findGroup(boGroup.id)!!
-        val alixGroup2: Group = alixClient.conversations.findGroup(boGroup2.id)!!
+        val alixGroup: Group = runBlocking { alixClient.conversations.findGroup(boGroup.id)!! }
+        val alixGroup2: Group = runBlocking { alixClient.conversations.findGroup(boGroup2.id)!! }
         var numGroups: UInt?
 
         assertEquals(runBlocking { alixGroup.messages() }.size, 1)

--- a/library/src/androidTest/java/org/xmtp/android/library/HistorySyncTest.kt
+++ b/library/src/androidTest/java/org/xmtp/android/library/HistorySyncTest.kt
@@ -101,7 +101,7 @@ class HistorySyncTest {
             alixClient2.conversations.syncAllConversations()
             Thread.sleep(2000)
         }
-        val alix2Group = alixClient2.conversations.findGroup(alixGroup.id)!!
+        val alix2Group = runBlocking { alixClient2.conversations.findGroup(alixGroup.id)!! }
 
         val consent = mutableListOf<ConsentRecord>()
         val job1 = CoroutineScope(Dispatchers.IO).launch {
@@ -135,7 +135,7 @@ class HistorySyncTest {
 
         Thread.sleep(2000)
         assertEquals(5, consent.size)
-        assertEquals(alixGroup.consentState(), ConsentState.DENIED)
+        assertEquals(runBlocking { alixGroup.consentState() }, ConsentState.DENIED)
         job.cancel()
         job1.cancel()
     }

--- a/library/src/main/java/org/xmtp/android/library/Conversation.kt
+++ b/library/src/main/java/org/xmtp/android/library/Conversation.kt
@@ -1,6 +1,8 @@
 package org.xmtp.android.library
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 import org.xmtp.android.library.codecs.EncodedContent
 import org.xmtp.android.library.libxmtp.ConversationDebugInfo
 import org.xmtp.android.library.libxmtp.DecodedMessage
@@ -64,6 +66,10 @@ sealed class Conversation {
             }
         }
 
+    @Deprecated(
+        message = "Use suspend disappearingMessageSettings()",
+        replaceWith = ReplaceWith("disappearingMessageSettings()")
+    )
     val disappearingMessageSettings: DisappearingMessageSettings?
         get() {
             return when (this) {
@@ -72,6 +78,17 @@ sealed class Conversation {
             }
         }
 
+    suspend fun disappearingMessageSettings(): DisappearingMessageSettings? = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
+            is Group -> group.disappearingMessageSettings()
+            is Dm -> dm.disappearingMessageSettings()
+        }
+    }
+
+    @Deprecated(
+        message = "Use suspend isDisappearingMessagesEnabled()",
+        replaceWith = ReplaceWith("isDisappearingMessagesEnabled()")
+    )
     val isDisappearingMessagesEnabled: Boolean
         get() {
             return when (this) {
@@ -80,8 +97,15 @@ sealed class Conversation {
             }
         }
 
-    suspend fun lastMessage(): DecodedMessage? {
-        return when (this) {
+    suspend fun isDisappearingMessagesEnabled(): Boolean = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
+            is Group -> group.isDisappearingMessagesEnabled()
+            is Dm -> dm.isDisappearingMessagesEnabled()
+        }
+    }
+
+    suspend fun lastMessage(): DecodedMessage? = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.lastMessage()
             is Dm -> dm.lastMessage()
         }
@@ -94,78 +118,78 @@ sealed class Conversation {
         }
     }
 
-    suspend fun members(): List<Member> {
-        return when (this) {
+    suspend fun members(): List<Member> = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.members()
             is Dm -> dm.members()
         }
     }
 
-    suspend fun clearDisappearingMessageSettings() {
-        return when (this) {
+    suspend fun clearDisappearingMessageSettings() = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.clearDisappearingMessageSettings()
             is Dm -> dm.clearDisappearingMessageSettings()
         }
     }
 
-    suspend fun updateDisappearingMessageSettings(disappearingMessageSettings: DisappearingMessageSettings?) {
-        return when (this) {
+    suspend fun updateDisappearingMessageSettings(disappearingMessageSettings: DisappearingMessageSettings?) = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.updateDisappearingMessageSettings(disappearingMessageSettings)
             is Dm -> dm.updateDisappearingMessageSettings(disappearingMessageSettings)
         }
     }
 
-    fun updateConsentState(state: ConsentState) {
-        return when (this) {
+    suspend fun updateConsentState(state: ConsentState) = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.updateConsentState(state)
             is Dm -> dm.updateConsentState(state)
         }
     }
 
-    fun consentState(): ConsentState {
-        return when (this) {
+    suspend fun consentState(): ConsentState = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.consentState()
             is Dm -> dm.consentState()
         }
     }
 
-    fun <T> prepareMessage(content: T, options: SendOptions? = null): String {
-        return when (this) {
+    suspend fun <T> prepareMessage(content: T, options: SendOptions? = null): String = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.prepareMessage(content, options)
             is Dm -> dm.prepareMessage(content, options)
         }
     }
 
-    fun prepareMessage(encodedContent: EncodedContent): String {
-        return when (this) {
+    suspend fun prepareMessage(encodedContent: EncodedContent): String = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.prepareMessage(encodedContent)
             is Dm -> dm.prepareMessage(encodedContent)
         }
     }
 
-    suspend fun <T> send(content: T, options: SendOptions? = null): String {
-        return when (this) {
+    suspend fun <T> send(content: T, options: SendOptions? = null): String = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.send(content = content, options = options)
             is Dm -> dm.send(content = content, options = options)
         }
     }
 
-    suspend fun send(encodedContent: EncodedContent): String {
-        return when (this) {
+    suspend fun send(encodedContent: EncodedContent): String = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.send(encodedContent)
             is Dm -> dm.send(encodedContent)
         }
     }
 
-    suspend fun send(text: String): String {
-        return when (this) {
+    suspend fun send(text: String): String = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.send(text)
             is Dm -> dm.send(text)
         }
     }
 
-    suspend fun sync() {
-        return when (this) {
+    suspend fun sync() = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.sync()
             is Dm -> dm.sync()
         }
@@ -177,8 +201,8 @@ sealed class Conversation {
         afterNs: Long? = null,
         direction: DecodedMessage.SortDirection = DecodedMessage.SortDirection.DESCENDING,
         deliveryStatus: DecodedMessage.MessageDeliveryStatus = DecodedMessage.MessageDeliveryStatus.ALL,
-    ): List<DecodedMessage> {
-        return when (this) {
+    ): List<DecodedMessage> = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.messages(limit, beforeNs, afterNs, direction, deliveryStatus)
             is Dm -> dm.messages(limit, beforeNs, afterNs, direction, deliveryStatus)
         }
@@ -190,8 +214,8 @@ sealed class Conversation {
         afterNs: Long? = null,
         direction: DecodedMessage.SortDirection = DecodedMessage.SortDirection.DESCENDING,
         deliveryStatus: DecodedMessage.MessageDeliveryStatus = DecodedMessage.MessageDeliveryStatus.ALL,
-    ): List<DecodedMessageV2> {
-        return when (this) {
+    ): List<DecodedMessageV2> = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.enrichedMessages(limit, beforeNs, afterNs, direction, deliveryStatus)
             is Dm -> dm.enrichedMessages(limit, beforeNs, afterNs, direction, deliveryStatus)
         }
@@ -203,8 +227,8 @@ sealed class Conversation {
         afterNs: Long? = null,
         direction: DecodedMessage.SortDirection = DecodedMessage.SortDirection.DESCENDING,
         deliveryStatus: DecodedMessage.MessageDeliveryStatus = DecodedMessage.MessageDeliveryStatus.ALL,
-    ): List<DecodedMessage> {
-        return when (this) {
+    ): List<DecodedMessage> = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.messagesWithReactions(
                 limit,
                 beforeNs,
@@ -217,23 +241,23 @@ sealed class Conversation {
         }
     }
 
-    suspend fun processMessage(messageBytes: ByteArray): DecodedMessage? {
-        return when (this) {
+    suspend fun processMessage(messageBytes: ByteArray): DecodedMessage? = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.processMessage(messageBytes)
             is Dm -> dm.processMessage(messageBytes)
         }
     }
 
-    suspend fun publishMessages() {
-        return when (this) {
+    suspend fun publishMessages() = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.publishMessages()
             is Dm -> dm.publishMessages()
         }
     }
 
     // Returns null if conversation is not paused, otherwise the min version required to unpause this conversation
-    fun pausedForVersion(): String? {
-        return when (this) {
+    suspend fun pausedForVersion(): String? = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.pausedForVersion()
             is Dm -> dm.pausedForVersion()
         }
@@ -254,37 +278,37 @@ sealed class Conversation {
         }
     }
 
-    fun getHmacKeys(): Keystore.GetConversationHmacKeysResponse {
-        return when (this) {
+    suspend fun getHmacKeys(): Keystore.GetConversationHmacKeysResponse = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.getHmacKeys()
             is Dm -> dm.getHmacKeys()
         }
     }
 
-    suspend fun getPushTopics(): List<String> {
-        return when (this) {
+    suspend fun getPushTopics(): List<String> = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.getPushTopics()
             is Dm -> dm.getPushTopics()
         }
     }
 
-    suspend fun getDebugInformation(): ConversationDebugInfo {
-        return when (this) {
+    suspend fun getDebugInformation(): ConversationDebugInfo = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.getDebugInformation()
             is Dm -> dm.getDebugInformation()
         }
     }
 
-    fun isActive(): Boolean {
-        return when (this) {
+    suspend fun isActive(): Boolean = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.isActive()
             is Dm -> dm.isActive()
         }
     }
 
     // Get the last read receipt timestamp (in nanoseconds) for each member of the conversation, keyed by inbox ID
-    fun getLastReadTimes(): Map<InboxId, Long> {
-        return when (this) {
+    suspend fun getLastReadTimes(): Map<InboxId, Long> = withContext(Dispatchers.IO) {
+        when (this@Conversation) {
             is Group -> group.getLastReadTimes()
             is Dm -> dm.getLastReadTimes()
         }

--- a/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -2,9 +2,11 @@ package org.xmtp.android.library
 
 import android.util.Log
 import com.google.protobuf.kotlin.toByteString
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.withContext
 import org.xmtp.android.library.codecs.ContentCodec
 import org.xmtp.android.library.codecs.EncodedContent
 import org.xmtp.android.library.codecs.compress
@@ -56,22 +58,51 @@ class Group(
     val lastActivityNs: Long
         get() = ffiLastMessage?.sentAtNs ?: createdAtNs
 
-    private suspend fun metadata(): FfiConversationMetadata {
-        return libXMTPGroup.groupMetadata()
+    private suspend fun metadata(): FfiConversationMetadata = withContext(Dispatchers.IO) {
+        libXMTPGroup.groupMetadata()
     }
 
-    private val permissions: FfiGroupPermissions
-        get() = libXMTPGroup.groupPermissions()
+    suspend fun permissions(): FfiGroupPermissions = withContext(Dispatchers.IO) {
+        libXMTPGroup.groupPermissions()
+    }
 
+    @Deprecated(
+        message = "Use suspend name()",
+        replaceWith = ReplaceWith("name()")
+    )
     val name: String
         get() = libXMTPGroup.groupName()
 
+    suspend fun name(): String = withContext(Dispatchers.IO) {
+        libXMTPGroup.groupName()
+    }
+
+    @Deprecated(
+        message = "Use suspend imageUrl()",
+        replaceWith = ReplaceWith("imageUrl()")
+    )
     val imageUrl: String
         get() = libXMTPGroup.groupImageUrlSquare()
 
+    suspend fun imageUrl(): String = withContext(Dispatchers.IO) {
+        libXMTPGroup.groupImageUrlSquare()
+    }
+
+    @Deprecated(
+        message = "Use suspend description()",
+        replaceWith = ReplaceWith("description()")
+    )
     val description: String
         get() = libXMTPGroup.groupDescription()
 
+    suspend fun description(): String = withContext(Dispatchers.IO) {
+        libXMTPGroup.groupDescription()
+    }
+
+    @Deprecated(
+        message = "Use suspend disappearingMessageSettings()",
+        replaceWith = ReplaceWith("disappearingMessageSettings()")
+    )
     val disappearingMessageSettings: DisappearingMessageSettings?
         get() = runCatching {
             libXMTPGroup.takeIf { isDisappearingMessagesEnabled }
@@ -81,21 +112,39 @@ class Group(
                 }
         }.getOrNull()
 
+    suspend fun disappearingMessageSettings(): DisappearingMessageSettings? = withContext(Dispatchers.IO) {
+        runCatching {
+            libXMTPGroup.takeIf { isDisappearingMessagesEnabled() }
+                ?.let { group ->
+                    group.conversationMessageDisappearingSettings()
+                        ?.let { DisappearingMessageSettings.createFromFfi(it) }
+                }
+        }.getOrNull()
+    }
+
+    @Deprecated(
+        message = "Use suspend isDisappearingMessagesEnabled()",
+        replaceWith = ReplaceWith("isDisappearingMessagesEnabled()")
+    )
     val isDisappearingMessagesEnabled: Boolean
         get() = libXMTPGroup.isConversationMessageDisappearingEnabled()
 
-    suspend fun send(text: String): String {
-        return send(encodeContent(content = text, options = null))
+    suspend fun isDisappearingMessagesEnabled(): Boolean = withContext(Dispatchers.IO) {
+        libXMTPGroup.isConversationMessageDisappearingEnabled()
     }
 
-    suspend fun <T> send(content: T, options: SendOptions? = null): String {
+    suspend fun send(text: String): String = withContext(Dispatchers.IO) {
+        send(encodeContent(content = text, options = null))
+    }
+
+    suspend fun <T> send(content: T, options: SendOptions? = null): String = withContext(Dispatchers.IO) {
         val preparedMessage = encodeContent(content = content, options = options)
-        return send(preparedMessage)
+        send(preparedMessage)
     }
 
-    suspend fun send(encodedContent: EncodedContent): String {
+    suspend fun send(encodedContent: EncodedContent): String = withContext(Dispatchers.IO) {
         val messageId = libXMTPGroup.send(contentBytes = encodedContent.toByteArray())
-        return messageId.toHex()
+        messageId.toHex()
     }
 
     fun <T> encodeContent(content: T, options: SendOptions?): EncodedContent {
@@ -122,25 +171,25 @@ class Group(
         }
     }
 
-    fun prepareMessage(encodedContent: EncodedContent): String {
-        return libXMTPGroup.sendOptimistic(encodedContent.toByteArray()).toHex()
+    suspend fun prepareMessage(encodedContent: EncodedContent): String = withContext(Dispatchers.IO) {
+        libXMTPGroup.sendOptimistic(encodedContent.toByteArray()).toHex()
     }
 
-    fun <T> prepareMessage(content: T, options: SendOptions? = null): String {
+    suspend fun <T> prepareMessage(content: T, options: SendOptions? = null): String = withContext(Dispatchers.IO) {
         val encodeContent = encodeContent(content = content, options = options)
-        return libXMTPGroup.sendOptimistic(encodeContent.toByteArray()).toHex()
+        libXMTPGroup.sendOptimistic(encodeContent.toByteArray()).toHex()
     }
 
-    suspend fun publishMessages() {
+    suspend fun publishMessages() = withContext(Dispatchers.IO) {
         libXMTPGroup.publishMessages()
     }
 
-    suspend fun sync() {
+    suspend fun sync() = withContext(Dispatchers.IO) {
         libXMTPGroup.sync()
     }
 
-    suspend fun lastMessage(): DecodedMessage? {
-        return if (ffiLastMessage != null) {
+    suspend fun lastMessage(): DecodedMessage? = withContext(Dispatchers.IO) {
+        if (ffiLastMessage != null) {
             DecodedMessage.create(ffiLastMessage)
         } else {
             messages(limit = 1).firstOrNull()
@@ -161,8 +210,8 @@ class Group(
         afterNs: Long? = null,
         direction: SortDirection = SortDirection.DESCENDING,
         deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.ALL,
-    ): List<DecodedMessage> {
-        return libXMTPGroup.findMessages(
+    ): List<DecodedMessage> = withContext(Dispatchers.IO) {
+        libXMTPGroup.findMessages(
             opts = FfiListMessagesOptions(
                 sentBeforeNs = beforeNs,
                 sentAfterNs = afterNs,
@@ -190,7 +239,7 @@ class Group(
         afterNs: Long? = null,
         direction: SortDirection = SortDirection.DESCENDING,
         deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.ALL,
-    ): List<DecodedMessage> {
+    ): List<DecodedMessage> = withContext(Dispatchers.IO) {
         val ffiMessageWithReactions = libXMTPGroup.findMessagesWithReactions(
             opts = FfiListMessagesOptions(
                 sentBeforeNs = beforeNs,
@@ -210,7 +259,7 @@ class Group(
             )
         )
 
-        return ffiMessageWithReactions.mapNotNull { ffiMessageWithReaction ->
+        ffiMessageWithReactions.mapNotNull { ffiMessageWithReaction ->
             DecodedMessage.create(ffiMessageWithReaction)
         }
     }
@@ -221,8 +270,8 @@ class Group(
         afterNs: Long? = null,
         direction: SortDirection = SortDirection.DESCENDING,
         deliveryStatus: MessageDeliveryStatus = MessageDeliveryStatus.ALL,
-    ): List<DecodedMessageV2> {
-        return libXMTPGroup.findMessagesV2(
+    ): List<DecodedMessageV2> = withContext(Dispatchers.IO) {
+        libXMTPGroup.findMessagesV2(
             opts = FfiListMessagesOptions(
                 sentBeforeNs = beforeNs,
                 sentAfterNs = afterNs,
@@ -244,50 +293,50 @@ class Group(
         }
     }
 
-    suspend fun processMessage(messageBytes: ByteArray): DecodedMessage? {
+    suspend fun processMessage(messageBytes: ByteArray): DecodedMessage? = withContext(Dispatchers.IO) {
         val message = libXMTPGroup.processStreamedConversationMessage(messageBytes)
-        return DecodedMessage.create(message)
+        DecodedMessage.create(message)
     }
 
-    fun updateConsentState(state: ConsentState) {
+    suspend fun updateConsentState(state: ConsentState) = withContext(Dispatchers.IO) {
         val consentState = ConsentState.toFfiConsentState(state)
         libXMTPGroup.updateConsentState(consentState)
     }
 
-    fun consentState(): ConsentState {
-        return ConsentState.fromFfiConsentState(libXMTPGroup.consentState())
+    suspend fun consentState(): ConsentState = withContext(Dispatchers.IO) {
+        ConsentState.fromFfiConsentState(libXMTPGroup.consentState())
     }
 
-    fun isActive(): Boolean {
-        return libXMTPGroup.isActive()
+    suspend fun isActive(): Boolean = withContext(Dispatchers.IO) {
+        libXMTPGroup.isActive()
     }
 
-    fun addedByInboxId(): InboxId {
-        return libXMTPGroup.addedByInboxId()
+    suspend fun addedByInboxId(): InboxId = withContext(Dispatchers.IO) {
+        libXMTPGroup.addedByInboxId()
     }
 
-    fun permissionPolicySet(): PermissionPolicySet {
-        return PermissionPolicySet.fromFfiPermissionPolicySet(permissions.policySet())
+    suspend fun permissionPolicySet(): PermissionPolicySet = withContext(Dispatchers.IO) {
+        PermissionPolicySet.fromFfiPermissionPolicySet(permissions().policySet())
     }
 
-    suspend fun creatorInboxId(): InboxId {
-        return metadata().creatorInboxId()
+    suspend fun creatorInboxId(): InboxId = withContext(Dispatchers.IO) {
+        metadata().creatorInboxId()
     }
 
-    suspend fun isCreator(): Boolean {
-        return metadata().creatorInboxId() == client.inboxId
+    suspend fun isCreator(): Boolean = withContext(Dispatchers.IO) {
+        metadata().creatorInboxId() == client.inboxId
     }
 
-    suspend fun addMembersByIdentity(identities: List<PublicIdentity>): GroupMembershipResult {
+    suspend fun addMembersByIdentity(identities: List<PublicIdentity>): GroupMembershipResult = withContext(Dispatchers.IO) {
         try {
             val result = libXMTPGroup.addMembers(identities.map { it.ffiPrivate })
-            return GroupMembershipResult(result)
+            GroupMembershipResult(result)
         } catch (e: Exception) {
             throw XMTPException("Unable to add member", e)
         }
     }
 
-    suspend fun removeMembersByIdentity(identities: List<PublicIdentity>) {
+    suspend fun removeMembersByIdentity(identities: List<PublicIdentity>) = withContext(Dispatchers.IO) {
         try {
             libXMTPGroup.removeMembers(identities.map { it.ffiPrivate })
         } catch (e: Exception) {
@@ -295,17 +344,17 @@ class Group(
         }
     }
 
-    suspend fun addMembers(inboxIds: List<InboxId>): GroupMembershipResult {
+    suspend fun addMembers(inboxIds: List<InboxId>): GroupMembershipResult = withContext(Dispatchers.IO) {
         validateInboxIds(inboxIds)
         try {
             val result = libXMTPGroup.addMembersByInboxId(inboxIds)
-            return GroupMembershipResult(result)
+            GroupMembershipResult(result)
         } catch (e: Exception) {
             throw XMTPException("Unable to add member", e)
         }
     }
 
-    suspend fun removeMembers(inboxIds: List<InboxId>) {
+    suspend fun removeMembers(inboxIds: List<InboxId>) = withContext(Dispatchers.IO) {
         validateInboxIds(inboxIds)
         try {
             libXMTPGroup.removeMembersByInboxId(inboxIds)
@@ -314,41 +363,41 @@ class Group(
         }
     }
 
-    suspend fun members(): List<Member> {
-        return libXMTPGroup.listMembers().map { Member(it) }
+    suspend fun members(): List<Member> = withContext(Dispatchers.IO) {
+        libXMTPGroup.listMembers().map { Member(it) }
     }
 
-    suspend fun peerInboxIds(): List<InboxId> {
+    suspend fun peerInboxIds(): List<InboxId> = withContext(Dispatchers.IO) {
         val ids = members().map { it.inboxId }.toMutableList()
         ids.remove(client.inboxId)
-        return ids
+        ids
     }
 
-    suspend fun updateName(name: String) {
+    suspend fun updateName(name: String) = withContext(Dispatchers.IO) {
         try {
-            return libXMTPGroup.updateGroupName(name)
+            libXMTPGroup.updateGroupName(name)
         } catch (e: Exception) {
             throw XMTPException("Permission denied: Unable to update group name", e)
         }
     }
 
-    suspend fun updateImageUrl(imageUrl: String) {
+    suspend fun updateImageUrl(imageUrl: String) = withContext(Dispatchers.IO) {
         try {
-            return libXMTPGroup.updateGroupImageUrlSquare(imageUrl)
+            libXMTPGroup.updateGroupImageUrlSquare(imageUrl)
         } catch (e: Exception) {
             throw XMTPException("Permission denied: Unable to update image url", e)
         }
     }
 
-    suspend fun updateDescription(description: String) {
+    suspend fun updateDescription(description: String) = withContext(Dispatchers.IO) {
         try {
-            return libXMTPGroup.updateGroupDescription(description)
+            libXMTPGroup.updateGroupDescription(description)
         } catch (e: Exception) {
             throw XMTPException("Permission denied: Unable to update group description", e)
         }
     }
 
-    suspend fun clearDisappearingMessageSettings() {
+    suspend fun clearDisappearingMessageSettings() = withContext(Dispatchers.IO) {
         try {
             libXMTPGroup.removeConversationMessageDisappearingSettings()
         } catch (e: Exception) {
@@ -356,7 +405,7 @@ class Group(
         }
     }
 
-    suspend fun updateDisappearingMessageSettings(disappearingMessageSettings: DisappearingMessageSettings?) {
+    suspend fun updateDisappearingMessageSettings(disappearingMessageSettings: DisappearingMessageSettings?) = withContext(Dispatchers.IO) {
         try {
             if (disappearingMessageSettings == null) {
                 clearDisappearingMessageSettings()
@@ -373,71 +422,71 @@ class Group(
         }
     }
 
-    suspend fun updateAddMemberPermission(newPermissionOption: PermissionOption) {
-        return libXMTPGroup.updatePermissionPolicy(
+    suspend fun updateAddMemberPermission(newPermissionOption: PermissionOption) = withContext(Dispatchers.IO) {
+        libXMTPGroup.updatePermissionPolicy(
             FfiPermissionUpdateType.ADD_MEMBER,
             PermissionOption.toFfiPermissionPolicy(newPermissionOption),
             null
         )
     }
 
-    suspend fun updateRemoveMemberPermission(newPermissionOption: PermissionOption) {
-        return libXMTPGroup.updatePermissionPolicy(
+    suspend fun updateRemoveMemberPermission(newPermissionOption: PermissionOption) = withContext(Dispatchers.IO) {
+        libXMTPGroup.updatePermissionPolicy(
             FfiPermissionUpdateType.REMOVE_MEMBER,
             PermissionOption.toFfiPermissionPolicy(newPermissionOption),
             null
         )
     }
 
-    suspend fun updateAddAdminPermission(newPermissionOption: PermissionOption) {
-        return libXMTPGroup.updatePermissionPolicy(
+    suspend fun updateAddAdminPermission(newPermissionOption: PermissionOption) = withContext(Dispatchers.IO) {
+        libXMTPGroup.updatePermissionPolicy(
             FfiPermissionUpdateType.ADD_ADMIN,
             PermissionOption.toFfiPermissionPolicy(newPermissionOption),
             null
         )
     }
 
-    suspend fun updateRemoveAdminPermission(newPermissionOption: PermissionOption) {
-        return libXMTPGroup.updatePermissionPolicy(
+    suspend fun updateRemoveAdminPermission(newPermissionOption: PermissionOption) = withContext(Dispatchers.IO) {
+        libXMTPGroup.updatePermissionPolicy(
             FfiPermissionUpdateType.REMOVE_ADMIN,
             PermissionOption.toFfiPermissionPolicy(newPermissionOption),
             null
         )
     }
 
-    suspend fun updateNamePermission(newPermissionOption: PermissionOption) {
-        return libXMTPGroup.updatePermissionPolicy(
+    suspend fun updateNamePermission(newPermissionOption: PermissionOption) = withContext(Dispatchers.IO) {
+        libXMTPGroup.updatePermissionPolicy(
             FfiPermissionUpdateType.UPDATE_METADATA,
             PermissionOption.toFfiPermissionPolicy(newPermissionOption),
             FfiMetadataField.GROUP_NAME
         )
     }
 
-    suspend fun updateDescriptionPermission(newPermissionOption: PermissionOption) {
-        return libXMTPGroup.updatePermissionPolicy(
+    suspend fun updateDescriptionPermission(newPermissionOption: PermissionOption) = withContext(Dispatchers.IO) {
+        libXMTPGroup.updatePermissionPolicy(
             FfiPermissionUpdateType.UPDATE_METADATA,
             PermissionOption.toFfiPermissionPolicy(newPermissionOption),
             FfiMetadataField.DESCRIPTION
         )
     }
 
-    suspend fun updateImageUrlPermission(newPermissionOption: PermissionOption) {
-        return libXMTPGroup.updatePermissionPolicy(
+    suspend fun updateImageUrlPermission(newPermissionOption: PermissionOption) = withContext(Dispatchers.IO) {
+        libXMTPGroup.updatePermissionPolicy(
             FfiPermissionUpdateType.UPDATE_METADATA,
             PermissionOption.toFfiPermissionPolicy(newPermissionOption),
             FfiMetadataField.IMAGE_URL_SQUARE
         )
     }
 
-    fun isAdmin(inboxId: InboxId): Boolean {
-        return libXMTPGroup.isAdmin(inboxId)
+    suspend fun isAdmin(inboxId: InboxId): Boolean = withContext(Dispatchers.IO) {
+        libXMTPGroup.isAdmin(inboxId)
     }
 
-    fun isSuperAdmin(inboxId: InboxId): Boolean {
-        return libXMTPGroup.isSuperAdmin(inboxId)
+    suspend fun isSuperAdmin(inboxId: InboxId): Boolean = withContext(Dispatchers.IO) {
+        libXMTPGroup.isSuperAdmin(inboxId)
     }
 
-    suspend fun addAdmin(inboxId: InboxId) {
+    suspend fun addAdmin(inboxId: InboxId) = withContext(Dispatchers.IO) {
         try {
             libXMTPGroup.addAdmin(inboxId)
         } catch (e: Exception) {
@@ -445,7 +494,7 @@ class Group(
         }
     }
 
-    suspend fun removeAdmin(inboxId: InboxId) {
+    suspend fun removeAdmin(inboxId: InboxId) = withContext(Dispatchers.IO) {
         try {
             libXMTPGroup.removeAdmin(inboxId)
         } catch (e: Exception) {
@@ -453,7 +502,7 @@ class Group(
         }
     }
 
-    suspend fun addSuperAdmin(inboxId: InboxId) {
+    suspend fun addSuperAdmin(inboxId: InboxId) = withContext(Dispatchers.IO) {
         try {
             libXMTPGroup.addSuperAdmin(inboxId)
         } catch (e: Exception) {
@@ -461,7 +510,7 @@ class Group(
         }
     }
 
-    suspend fun removeSuperAdmin(inboxId: InboxId) {
+    suspend fun removeSuperAdmin(inboxId: InboxId) = withContext(Dispatchers.IO) {
         try {
             libXMTPGroup.removeSuperAdmin(inboxId)
         } catch (e: Exception) {
@@ -469,17 +518,17 @@ class Group(
         }
     }
 
-    fun listAdmins(): List<InboxId> {
-        return libXMTPGroup.adminList()
+    suspend fun listAdmins(): List<InboxId> = withContext(Dispatchers.IO) {
+        libXMTPGroup.adminList()
     }
 
-    fun listSuperAdmins(): List<InboxId> {
-        return libXMTPGroup.superAdminList()
+    suspend fun listSuperAdmins(): List<InboxId> = withContext(Dispatchers.IO) {
+        libXMTPGroup.superAdminList()
     }
 
     // Returns null if group is not paused, otherwise the min version required to unpause this group
-    fun pausedForVersion(): String? {
-        return libXMTPGroup.pausedForVersion()
+    suspend fun pausedForVersion(): String? = withContext(Dispatchers.IO) {
+        libXMTPGroup.pausedForVersion()
     }
 
     fun streamMessages(onClose: (() -> Unit)? = null): Flow<DecodedMessage> = callbackFlow {
@@ -518,7 +567,7 @@ class Group(
         awaitClose { stream.end() }
     }
 
-    fun getHmacKeys(): Keystore.GetConversationHmacKeysResponse {
+    suspend fun getHmacKeys(): Keystore.GetConversationHmacKeysResponse = withContext(Dispatchers.IO) {
         val hmacKeysResponse = Keystore.GetConversationHmacKeysResponse.newBuilder()
         val conversations = libXMTPGroup.getHmacKeys()
         conversations.iterator().forEach {
@@ -534,19 +583,19 @@ class Group(
                 hmacKeys.build()
             )
         }
-        return hmacKeysResponse.build()
+        hmacKeysResponse.build()
     }
 
     fun getPushTopics(): List<String> {
         return listOf(topic)
     }
 
-    suspend fun getDebugInformation(): ConversationDebugInfo {
-        return ConversationDebugInfo(libXMTPGroup.conversationDebugInfo())
+    suspend fun getDebugInformation(): ConversationDebugInfo = withContext(Dispatchers.IO) {
+        ConversationDebugInfo(libXMTPGroup.conversationDebugInfo())
     }
 
-    fun getLastReadTimes(): Map<InboxId, Long> {
-        return libXMTPGroup.getLastReadTimes()
+    suspend fun getLastReadTimes(): Map<InboxId, Long> = withContext(Dispatchers.IO) {
+        libXMTPGroup.getLastReadTimes()
     }
 
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
### Default database and FFI-backed messaging APIs to `Dispatchers.IO` and convert sync conversation/group methods to suspend across `Client`, `Conversations`, `Conversation`, `Group`, and `Dm`
This change routes database- and FFI-backed operations to `Dispatchers.IO` and converts multiple synchronous conversation and group accessors to suspend functions. It updates instance and companion methods in messaging primitives and adjusts tests and the example app accordingly.

- Wraps core `Client` factories, revocation utilities, database operations, and inbox queries with `withContext(Dispatchers.IO)` in [Client.kt](https://github.com/xmtp/xmtp-android/pull/471/files#diff-7f5f11ae5a1cc09075430850830b536bb9e472ea3e97397c396cfefea4e1e0da)
- Converts key `Conversations` lookups, listings, sync, and creation helpers to suspend and executes them on `Dispatchers.IO` in [Conversations.kt](https://github.com/xmtp/xmtp-android/pull/471/files#diff-479fe53ececf1836cd910bfba9a721b20fce9fd212b204329abef95ff79429f9)
- Converts various `Conversation` consent/state, preparation, retrieval, activity checks, and metadata helpers to suspend and dispatches to IO in [Conversation.kt](https://github.com/xmtp/xmtp-android/pull/471/files#diff-e5f667529c5e94c317bb484d5229352677d7b7636451fb2f1437d0b93c0beabf)
- Converts `Group` metadata, permissions, membership/admin updates, consent/state, message preparation/retrieval, and role checks to suspend and dispatches to IO in [Group.kt](https://github.com/xmtp/xmtp-android/pull/471/files#diff-0bc942e458f483ac87a55f0bd8d9ee89abc0a03d9cca7fe44d8081acf2749c5b)
- Converts `Dm` metadata, consent/state, message preparation/retrieval, and activity checks to suspend and dispatches to IO in [Dm.kt](https://github.com/xmtp/xmtp-android/pull/471/files#diff-5221bfec9e9bb6a23945941677af4e18af500b41e47b6a4fb6d75a26b45359a6)
- Updates tests to call new suspend APIs via `runBlocking` in files under [library/src/androidTest](https://github.com/xmtp/xmtp-android/pull/471/files#diff-32b7a3d7d2da1066c1dccf1ca08113f4dd0d5db0bfcfd31eb54734ab5c55353b) and syncs conversations before computing subscriptions in the example app in [MainViewModel.kt](https://github.com/xmtp/xmtp-android/pull/471/files#diff-5e203c96c0640e7bf673321179dad5627eecb7d57165d60d05b60344604ca431)

#### 📍Where to Start
Start with the database and FFI dispatching changes in `Client` companion and instance methods in [Client.kt](https://github.com/xmtp/xmtp-android/pull/471/files#diff-7f5f11ae5a1cc09075430850830b536bb9e472ea3e97397c396cfefea4e1e0da), then follow call sites into `Conversations` in [Conversations.kt](https://github.com/xmtp/xmtp-android/pull/471/files#diff-479fe53ececf1836cd910bfba9a721b20fce9fd212b204329abef95ff79429f9) and the `Conversation`/`Group`/`Dm` suspend conversions.

----

_[Macroscope](https://app.macroscope.com) summarized f834c0b._